### PR TITLE
docs(asp-provider): full provider README + claim-scrub gate (#44, #45)

### DIFF
--- a/packages/asp-provider/README.md
+++ b/packages/asp-provider/README.md
@@ -1,3 +1,118 @@
 # @the-open-engine/opcore-asp-provider
 
-Standalone ASP Core check provider facade for Opcore validation.
+A standalone **ASP Core check provider** facade over Opcore validation.
+
+It runs as a small stdio JSON-RPC process, `opcore-asp-provider --stdio`, that an
+ASP host or manager launches. It receives a baseline and a changeset, maps that
+changeset into hypothetical validation overlays, runs Opcore's TypeScript and Rust
+validation checks against them, and returns provider-owned diagnostics and coverage.
+
+**Providers assess; hosts decide.** This package never makes a policy decision, never
+holds authority, never grants a gate, and never applies an edit. It reports findings
+and honest coverage; the ASP host owns the allow/deny/transaction outcome.
+
+## What it is (and is not)
+
+- It **is** an ASP Core `check` capability provider over Opcore validation.
+- It **is** read-only with respect to the host workspace and the network.
+- It is **not** an ASP host, manager, catalog, or authority.
+- It is **not** a `lattice asp` or `opcore asp` CLI route — there is no ASP router
+  command. The provider is launched as its own process.
+- It does **not** use ACE as a carrier or provisioner, does **not** read or write
+  `.ace/runtime`, and does **not** execute `rox`, `crg`, or `cix`.
+- It makes no ASP-standard, old-tool-replacement, security/SAST, all-stack,
+  AI-authorship, automatic-fix, or blended-quality-score claim.
+
+## Install
+
+```sh
+npm install @the-open-engine/opcore-asp-provider
+```
+
+This installs the `opcore-asp-provider` bin alongside its Opcore validation
+dependencies. The package is launched by an ASP host/manager, not run directly by an
+end user. A provisional install manifest is published at
+`@the-open-engine/opcore-asp-provider/manifests/opcore-asp-provider.provisional.json`
+(see [Provisional manifest](#provisional-manifest)).
+
+## Launch
+
+```sh
+opcore-asp-provider --stdio
+```
+
+The process speaks newline-delimited JSON-RPC 2.0 over stdin/stdout. Without
+`--stdio` it prints usage and exits non-zero. There is no other entrypoint.
+
+## Protocol
+
+Protocol version: `asp/0.1`. Capability family: `check`.
+
+### Lifecycle
+
+1. `initialize` (request) — the host sends `protocolVersion`, optional host metadata,
+   and an optional workspace `baseline`. A mismatched `protocolVersion` is rejected.
+   The provider replies with its advertised check capability metadata.
+2. `initialized` (notification) — the host confirms the session and sends the
+   `grantedPermissions` (read globs only; write/network are not requested).
+3. `check/evaluate` (request) — sent after `initialized`; evaluating before the grant
+   fails closed. The provider returns an `Assessment`.
+
+`check/evaluate` accepts a `ChangeSet` (`baseline` + `changes[]`), an optional
+`changesetDigest`, `comparison` (`all` | `introduced`), `callSite`
+(`interactive` | `gate` | `sweep`), an optional `timeoutMs`, and an optional check
+selection. Changes are `create`, `modify`, `delete`, or `rename`.
+
+### Host callbacks
+
+The provider owns no file access of its own. All ASP-owned content is read back
+through host callbacks:
+
+- `workspace/listTree` — enumerate paths/globs the provider needs.
+- `workspace/readBlob` — fetch blob content by id for baseline and changeset
+  after-state.
+
+Changeset entries map to validation overlays: `create`/`modify` become write
+overlays sourced from the after-blob, `delete` removes the path, and `rename` is
+modeled as delete-old plus write-new. The validation file view then exposes the
+hypothetical after-state to checks without ever mutating the host workspace.
+
+## Permissions
+
+The provider requests the minimum:
+
+- `read`: workspace blobs needed for the changeset and its baseline (via callbacks).
+- `write`: **false** — it never writes the workspace.
+- `network`: **false** — it never makes network calls.
+
+It exposes no apply, decision, authority, assurance, transaction, or gate fields.
+
+## Coverage and degraded honesty
+
+Assessments report coverage honestly rather than implying clean exhaustive results:
+
+- TypeScript/JavaScript checks (syntax, type, import-graph, dead-code, relevant-tests)
+  are the deep surface.
+- Rust checks (source-hygiene, fmt, cargo-check, clippy, rustdoc, import-graph,
+  dead-code, unused-deps, file-length, function-metrics) are useful when the
+  toolchain is present.
+- Missing graph facts, missing toolchains, or unavailable provider surfaces are
+  reported as `degraded` or `unsupported` coverage parts with a reason and
+  requirement — never as silent gaps or fabricated findings.
+
+Each assessment binds `validAsOf.baseline`, `validAsOf.changesetDigest`, and
+`validAsOf.blobs` to the exact host input and read set, so a host can tell precisely
+what state the assessment was computed against.
+
+## Provisional manifest
+
+`manifests/opcore-asp-provider.provisional.json` is **install metadata only**. It
+records the provider id, package, bin (`opcore-asp-provider --stdio`), capability
+family, check ids, read-only permissions, and a `dist/index.js` checksum. It carries
+`noAuthority`, `noTrust`, and `noGateGrant` and grants no trust, authority, or gate
+permission. Whether the canonical packaged ASP server manifest is owned here or
+converted by the ASP manager is tracked in the Opcore release-readiness coordination.
+
+## License
+
+MIT.

--- a/tests/asp-provider.test.mjs
+++ b/tests/asp-provider.test.mjs
@@ -146,6 +146,68 @@ describe("Opcore ASP provider", () => {
   });
 });
 
+// #15/#45: claim-scrub gate over the provider README, package.json, and manifest source.
+// Reads source files only, so it runs in `npm test` without a prior build. It locks the
+// "providers assess, hosts decide" semantics and forbids overclaim phrases that would never
+// legitimately appear on the provider surface (host authority, ASP-standard, old-tool
+// replacement, security/SAST, all-stack, AI-authorship, automatic-fix, blended score).
+describe("Opcore ASP provider claim scrub", () => {
+  const readmePath = join(repoRoot, "packages/asp-provider/README.md");
+  const packageJsonPath = join(repoRoot, "packages/asp-provider/package.json");
+  const manifestSourcePath = join(repoRoot, "packages/asp-provider/src/manifest.ts");
+
+  // package.json description/keywords are pure marketing metadata with no disclaimer prose,
+  // so a bare forbidden-token scan there is meaningful (unlike the README, which legitimately
+  // names these concepts in order to disclaim them).
+  const forbiddenMetadataTokens = [
+    /\bstandard\b/i,
+    /\bauthority\b/i,
+    /\breplaces?\b/i,
+    /\bsecurity\b/i,
+    /\bSAST\b/i,
+    /\bgate\b/i,
+    /\ball[- ]stack\b/i,
+    /\bblended\b/i,
+    /\bAI authorship\b/i
+  ];
+
+  it("keeps the providers-assess / hosts-decide semantics in the README", () => {
+    const readme = readFileSync(readmePath, "utf8");
+    assert.match(readme, /providers assess/i, "README must state that providers assess");
+    assert.match(readme, /hosts decide/i, "README must state that hosts decide");
+    assert.match(readme, /never (?:makes a policy decision|holds authority)/i, "README must disclaim host authority");
+    assert.match(readme, /no ASP router|there is no ASP router/i, "README must disclaim an ASP router command");
+    assert.match(readme, /\bwrite\b[^.\n]*\bfalse\b/i, "README must state write is false");
+    assert.match(readme, /\bnetwork\b[^.\n]*\bfalse\b/i, "README must state network is false");
+    assert.match(readme, /degraded|unsupported/i, "README must describe degraded/unsupported coverage honesty");
+    assert.match(readme, /does \*\*not\*\* use ACE|not use ACE as a carrier/i, "README must disclaim ACE as carrier/provisioner");
+  });
+
+  it("rejects forbidden marketing tokens in package.json metadata", () => {
+    const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const marketing = [manifest.description ?? "", ...(manifest.keywords ?? [])].join(" ");
+    for (const pattern of forbiddenMetadataTokens) {
+      assert.doesNotMatch(marketing, pattern, `Forbidden provider marketing token ${pattern} in package.json`);
+    }
+  });
+
+  it("forbids ASP router command examples in the README", () => {
+    const readme = readFileSync(readmePath, "utf8");
+    for (const block of readme.match(/```[\s\S]*?```/g) ?? []) {
+      assert.doesNotMatch(block, /\b(?:opcore|lattice)\s+asp\b/i, "README code blocks must not show an ASP router command");
+    }
+  });
+
+  it("keeps no-authority manifest flags in the manifest source", () => {
+    const source = readFileSync(manifestSourcePath, "utf8");
+    assert.match(source, /noAuthority:\s*true/);
+    assert.match(source, /noTrust:\s*true/);
+    assert.match(source, /noGateGrant:\s*true/);
+    assert.match(source, /write:\s*false/);
+    assert.match(source, /network:\s*false/);
+  });
+});
+
 function spawnProvider(host) {
   const child = spawn(process.execPath, [providerBin, "--stdio"], {
     cwd: repoRoot,


### PR DESCRIPTION
Closes #44. Closes #45.
EPIC #15.

## What
- **README (#44):** rewrites `packages/asp-provider/README.md` from a 3-line stub into a full provider doc — install, `opcore-asp-provider --stdio` launch, `asp/0.1` lifecycle (`initialize`/`initialized`/`check/evaluate`), `workspace/listTree` + `workspace/readBlob` host callbacks, read-only permissions (`write:false`, `network:false`, no apply/decision fields), changeset→overlay mapping, degraded/unsupported coverage honesty, `validAsOf` binding, and explicit **"providers assess; hosts decide"** plus no-router / no-ACE / no-authority disclaimers. Facts cross-checked against `src/protocol.ts`, `src/index.ts`, `src/validation-composition.ts`, `src/workspace.ts`.
- **Claim-scrub gate (#45):** adds a self-contained `describe("Opcore ASP provider claim scrub")` block in `tests/asp-provider.test.mjs` that reads source files only (no build/install; runs in plain `npm test`) — required README assertions, no-ASP-router code-block check, package.json marketing-token scrub, and manifest `noAuthority/noTrust/noGateGrant` + `write:false`/`network:false` retention.

## Why this design
The scrub guards the README via **required positive assertions** rather than a bare forbidden-token scan, because a correct provider README legitimately *names* forbidden concepts (security/SAST, AI-authorship, …) in order to disclaim them. Bare-token scanning is applied only to package.json marketing metadata, which carries no disclaimer prose.

## Verification
```
node --test --test-name-pattern="claim scrub" tests/asp-provider.test.mjs
# ✔ Opcore ASP provider claim scrub — tests 4, pass 4, fail 0
```
`packages/asp-provider/README.md` is not in release-hygiene `launchFacingFiles()`, so the `lattice asp` negated disclaimer does not trip the launch-facing naming gate; README stays in the package `files`/packlist (no pack:check drift).

## Scope / boundaries
Docs + one self-contained test. No package behavior, manifest, or receipt changes. No public release, npm publish, or visibility change. Most of EPIC #15 already shipped in #118 (manifest/provider/installed-bin tests) and #120 (dogfood); this PR closes the README + claim-scrub gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)