### PR TITLE
fix(inspect): node-id `inspect references` returns graph-backed references

### DIFF
--- a/packages/opcore/src/lattice/inspect-adapter.ts
+++ b/packages/opcore/src/lattice/inspect-adapter.ts
@@ -6,7 +6,6 @@ import type {
   CommandRouteStatus,
   GraphFactQuerySelector,
   GraphFactQueryResult,
-  GraphNamedQueryResult,
   GraphProviderStatus,
   InspectFailureCategory,
   InspectRouteFailure,
@@ -16,7 +15,6 @@ import type {
 } from "@the-open-engine/opcore-contracts";
 import { createCommandRouterResult } from "@the-open-engine/opcore-contracts";
 import {
-  graphProviderNamedQuery,
   graphProviderQuery,
   graphProviderSearch
 } from "@the-open-engine/opcore-graph";
@@ -111,10 +109,10 @@ function inspectSignatureResult(request: CommandAdapterRequest, options: Inspect
 function inspectNodeReferencesResult(request: CommandAdapterRequest, options: InspectOptions, target: InspectSymbolTarget): CommandRouterResult {
   const nodeId = target.nodeId;
   if (!nodeId) return inspectFailureResult(request, "references", "malformed_target", "lattice inspect references node target requires nodeId");
-  const graphQuery = graphProviderNamedQuery(options.repo, {
-    queryKind: "callers_of",
-    target: nodeId,
-    limit: options.limit
+  const graphQuery = graphProviderQuery(options.repo, {
+    kind: "symbols",
+    ids: [nodeId],
+    limit: options.limit ?? 1
   });
   if (graphQuery.status.state !== "available") {
     return inspectFailureResult(
@@ -127,6 +125,34 @@ function inspectNodeReferencesResult(request: CommandAdapterRequest, options: In
       graphQuery
     );
   }
+  if (!("nodes" in graphQuery) || graphQuery.nodes.length === 0) {
+    return inspectFailureResult(request, "references", "target_not_found", `Inspect references node target not found: ${nodeId}`, graphQuery.status, target, graphQuery);
+  }
+  const candidate = graphQuery.nodes[0];
+  const parsed = graphNodeTarget(candidate.id, candidate.path, candidate.name);
+  if (!parsed) {
+    return inspectFailureResult(request, "references", "target_not_found", `Inspect references node target is not a supported class/function/type node: ${nodeId}`, graphQuery.status, target, graphQuery);
+  }
+  if (!isSupportedInspectSourcePath(parsed.path)) {
+    return inspectFailureResult(request, "references", "unsupported_language", `Unsupported inspect references target language: ${parsed.path}`, graphQuery.status, target, graphQuery);
+  }
+  const resolution = resolveInspectReferences(options.repoRoot, {
+    path: parsed.path,
+    symbolName: parsed.symbolName,
+    line: options.line,
+    column: options.column,
+    limit: options.limit,
+    graphTargetOnly: true,
+    graphNodeIds: [candidate.id],
+    graphCandidates: [candidate],
+    graphKind: candidate.kind,
+    graphSymbolName: candidate.name ?? parsed.symbolName
+  });
+  if (!resolution.ok) {
+    return inspectFailureResult(request, "references", resolution.category, resolution.message, graphQuery.status, resolution.target ?? target, graphQuery, {
+      candidates: resolution.candidates
+    });
+  }
   return createCommandRouterResult({
     bin: request.bin,
     argv: request.argv,
@@ -134,15 +160,15 @@ function inspectNodeReferencesResult(request: CommandAdapterRequest, options: In
     owner: "inspect",
     status: "ok",
     json: request.json,
-    message: "lattice inspect references: graph provider returned read-only results.",
+    message: "lattice inspect references: language service returned read-only references.",
     providerStatus: graphQuery.status,
     graphQuery,
     inspectResult: {
       route: "references",
       status: "ok",
-      target,
+      target: resolution.target,
       providerStatus: graphQuery.status,
-      references: []
+      references: resolution.references
     }
   });
 }
@@ -447,7 +473,7 @@ function inspectFailureResult(
   message: string,
   providerStatus?: GraphProviderStatus,
   target?: InspectSymbolTarget,
-  graphQuery?: GraphFactQueryResult | GraphNamedQueryResult,
+  graphQuery?: GraphFactQueryResult,
   options: { candidates?: readonly InspectSymbolTarget[] } = {}
 ): CommandRouterResult {
   const failure: InspectRouteFailure = {

--- a/scripts/generate-cutover-receipt.mjs
+++ b/scripts/generate-cutover-receipt.mjs
@@ -562,6 +562,9 @@ function assertCommandPayload(id, parsed) {
   if (id === "inspect-signature" && (!Array.isArray(parsed.inspectResult?.signatures) || parsed.inspectResult.signatures.length === 0)) {
     throw new Error("inspect-signature must return read-only signature entries");
   }
+  if (id === "inspect-references" && (!Array.isArray(parsed.inspectResult?.references) || parsed.inspectResult.references.length === 0)) {
+    throw new Error("inspect-references must return read-only reference entries");
+  }
   if (id === "inspect-implementations" && parsed.inspectResult?.implementations?.length < 1) {
     throw new Error("inspect-implementations must return implementation evidence");
   }

--- a/tests/cli-canonical-surface.test.mjs
+++ b/tests/cli-canonical-surface.test.mjs
@@ -90,8 +90,12 @@ describe("canonical CLI surface", () => {
       assert.equal(Object.hasOwn(implementations.inspectResult, "signatures"), false);
       assert.equal(symbols.graphQuery.nodes.some((node) => node.id === "function:src/components/GreetingCard.tsx#GreetingCard"), true);
       assert.equal(definition.graphQuery.nodes[0].id, "function:src/components/GreetingCard.tsx#GreetingCard");
-      assert.equal(references.graphQuery.queryKind, "callers_of");
+      assert.equal(references.graphQuery.nodes.some((node) => node.id === "function:src/components/GreetingCard.tsx#GreetingCard"), true);
       assert.equal(references.inspectResult.status, "ok");
+      assert.equal(references.inspectResult.references.length > 0, true);
+      for (const reference of references.inspectResult.references) {
+        assert.deepEqual(reference.evidence.graphNodeIds, ["function:src/components/GreetingCard.tsx#GreetingCard"]);
+      }
       assert.equal(references.inspectResult.target.nodeId, "function:src/components/GreetingCard.tsx#GreetingCard");
       assert.equal(signature.inspectResult.route, "signature");
       assert.equal(implementations.inspectResult.route, "implementations");

--- a/tests/command-router.test.mjs
+++ b/tests/command-router.test.mjs
@@ -283,9 +283,12 @@ describe("lattice command router", () => {
       assert.equal(Object.hasOwn(implementations.inspectResult, "signatures"), false);
       assert.equal(symbols.graphQuery.nodes.some((node) => node.id === "function:src/components/GreetingCard.tsx#GreetingCard"), true);
       assert.equal(definition.graphQuery.nodes[0].id, "function:src/components/GreetingCard.tsx#GreetingCard");
-      assert.equal(references.graphQuery.queryKind, "callers_of");
-      assert.equal(references.graphQuery.nodes.some((node) => node.id === "test:src/__tests__/greeting.test.ts#renders greeting cards"), true);
+      assert.equal(references.graphQuery.nodes.some((node) => node.id === "function:src/components/GreetingCard.tsx#GreetingCard"), true);
       assert.equal(references.inspectResult.status, "ok");
+      assert.equal(references.inspectResult.references.length > 0, true);
+      for (const reference of references.inspectResult.references) {
+        assert.deepEqual(reference.evidence.graphNodeIds, ["function:src/components/GreetingCard.tsx#GreetingCard"]);
+      }
       assert.equal(references.inspectResult.target.nodeId, "function:src/components/GreetingCard.tsx#GreetingCard");
       assert.equal(signature.inspectResult.route, "signature");
       assert.equal(implementations.inspectResult.route, "implementations");

--- a/tests/inspect-references.test.mjs
+++ b/tests/inspect-references.test.mjs
@@ -67,10 +67,11 @@ it("rejects line-disambiguated targets that are not backed by graph facts", asyn
 it("preserves node-id references with graphQuery and typed inspectResult", async () => {
   await withFixtureCopy(async (fixtureRoot) => {
     await buildGraph(fixtureRoot);
+    const nodeId = "function:src/components/GreetingCard.tsx#GreetingCard";
     const result = await routeCommand([
       "inspect",
       "references",
-      "function:src/components/GreetingCard.tsx#GreetingCard",
+      nodeId,
       "--repo",
       fixtureRoot,
       "--limit",
@@ -80,9 +81,11 @@ it("preserves node-id references with graphQuery and typed inspectResult", async
     assert.equal(result.owner, "inspect");
     assert.equal(result.status, "ok");
     assert.equal(result.providerStatus.state, "available");
-    assert.equal(result.graphQuery.queryKind, "callers_of");
+    assert.equal(result.graphQuery.nodes.some((node) => node.id === nodeId), true);
     assert.equal(result.inspectResult.status, "ok");
-    assert.equal(result.inspectResult.target.nodeId, "function:src/components/GreetingCard.tsx#GreetingCard");
+    assert.equal(result.inspectResult.references.length > 0, true);
+    for (const reference of result.inspectResult.references) assert.deepEqual(reference.evidence.graphNodeIds, [nodeId]);
+    assert.equal(result.inspectResult.target.nodeId, nodeId);
     assert.equal(Object.hasOwn(result, "alias"), false);
     assert.equal(Object.hasOwn(result, removedLegacyCommandField), false);
   });


### PR DESCRIPTION
Closes #49

## Summary
- Makes node-id `lattice inspect references <node-id>` resolve the graph symbol and materialize language-service references.
- Updates inspect/router tests to assert graph-backed reference evidence for `GreetingCard`.
- Strengthens the cutover receipt payload assertion so inspect references must return at least one reference.

## Validation
- `npm run build`
- `node --test tests/inspect-references.test.mjs`
- `node --test tests/command-router.test.mjs`
- `node --test tests/cli-canonical-surface.test.mjs`

Generated with zeroshot finish