### PR TITLE
fix(ci): avoid Node 22 unsupported using syntax

### DIFF
--- a/tests/graph-pipeline-cli.test.mjs
+++ b/tests/graph-pipeline-cli.test.mjs
@@ -260,8 +260,12 @@ describe("graph pipeline CLI", () => {
       assert.equal(build.graphPipeline.summary.discoveredFiles, 2);
       assert.equal(build.graphPipeline.summary.parsedFiles, 1);
       assert.deepEqual(build.graphPipeline.summary.changedFiles, ["src/app.ts", "src/tool.py"]);
-      using db = new DatabaseSync(join(temp, ".lattice/graph/graph.db"));
-      assert.equal(db.prepare("select count(*) as count from nodes where path = ?").get("src/tool.py").count, 0);
+      const db = new DatabaseSync(join(temp, ".lattice/graph/graph.db"));
+      try {
+        assert.equal(db.prepare("select count(*) as count from nodes where path = ?").get("src/tool.py").count, 0);
+      } finally {
+        db.close();
+      }
     } finally {
       rmSync(temp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Replaces explicit resource management syntax in `tests/graph-pipeline-cli.test.mjs` with a plain `try/finally` database close.
- Fixes the post-merge CI failure from PR #66 under Node v22.23.0.

## Validation
- `npx -y node@22.23.0 --check tests/graph-pipeline-cli.test.mjs`
- `npm run build`
- `npx -y node@22.23.0 --test tests/graph-pipeline-cli.test.mjs`