### PR TITLE
chore(release): restore release receipt docs

### DIFF
--- a/docs/release/release-receipt.json
+++ b/docs/release/release-receipt.json
@@ -1,0 +1,2301 @@
+{
+  "schemaVersion": 1,
+  "issue": "#29",
+  "origin": "covibes-authored-release-proof",
+  "generatedAt": "2026-06-26T10:44:16.233Z",
+  "commitSha": "f51e3ae668444c39c703db95a40b6b20de9a1c89",
+  "privateRepo": true,
+  "packageNames": [
+    "@the-open-engine/lattice-contracts",
+    "@the-open-engine/opcore",
+    "@the-open-engine/lattice-cli",
+    "@the-open-engine/lattice-graph",
+    "@the-open-engine/opcore-graph-core-darwin-arm64",
+    "@the-open-engine/opcore-graph-core-darwin-x64",
+    "@the-open-engine/opcore-graph-core-linux-x64",
+    "@the-open-engine/lattice-edit",
+    "@the-open-engine/lattice-validation",
+    "@the-open-engine/lattice-validation-rust",
+    "@the-open-engine/lattice-validation-typescript",
+    "@the-open-engine/opcore-asp-provider"
+  ],
+  "commandGroups": [
+    "graph",
+    "inspect",
+    "edit",
+    "check",
+    "validate",
+    "status",
+    "doctor"
+  ],
+  "packages": [
+    {
+      "packageName": "@the-open-engine/lattice-contracts",
+      "packageRoot": "packages/contracts",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-contracts",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "schemas",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {},
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-contracts-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-contracts-0.1.0-alpha.0.tgz",
+        "sha256": "6801e8dda1ed82724bfa95d70ab7b7c4af4f87016a7471eb4cdfb425dda382b5",
+        "integrity": "sha512-StFb2r2iX3ArQJkETEd657o4AAK6nwXcVvWZPgbiC+KoDXM/RJA8x35goNKxtUJnUQ+Skhn6ZPMEJ3oi0c/eVw==",
+        "shasum": "596051f69bf37b1cf717c774678cfa764c209c3a"
+      },
+      "files": [
+        "README.md",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "package.json",
+        "schemas/lattice-contracts.schema.json"
+      ],
+      "fileCount": 6,
+      "expectedFiles": [
+        "README.md",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "package.json",
+        "schemas/lattice-contracts.schema.json"
+      ],
+      "expectedFileCount": 6,
+      "bins": {},
+      "descriptorReferences": [
+        {
+          "id": "contracts-schema",
+          "packageName": "@the-open-engine/lattice-contracts",
+          "path": "schemas/lattice-contracts.schema.json",
+          "type": "schema",
+          "required": true
+        }
+      ],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/opcore",
+      "packageRoot": "packages/opcore",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/opcore",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {
+          "opcore": "dist/index.js"
+        },
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-graph": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation-rust": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation-typescript": "0.1.0-alpha.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-opcore-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-opcore-0.1.0-alpha.0.tgz",
+        "sha256": "8d2858dad630606d3bd6984d9a13a547a04a2f469750172e031bb63577ac3e32",
+        "integrity": "sha512-sF2nitsk8ZOQOzpwPh/ptyy+HOvxWwc08j1nRf5HrpMeQgQF9alp3WnzU8pxEKm5TMFUAg7ripSTPPUmg4iPxw==",
+        "shasum": "172556d8d773fc2cb1e163affa566e25c71c4005"
+      },
+      "files": [
+        "README.md",
+        "dist/check.d.ts",
+        "dist/check.d.ts.map",
+        "dist/check.js",
+        "dist/graph-provider-client.d.ts",
+        "dist/graph-provider-client.d.ts.map",
+        "dist/graph-provider-client.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/init.d.ts",
+        "dist/init.d.ts.map",
+        "dist/init.js",
+        "dist/reporting.d.ts",
+        "dist/reporting.d.ts.map",
+        "dist/reporting.js",
+        "dist/router.d.ts",
+        "dist/router.d.ts.map",
+        "dist/router.js",
+        "dist/scan.d.ts",
+        "dist/scan.d.ts.map",
+        "dist/scan.js",
+        "dist/status.d.ts",
+        "dist/status.d.ts.map",
+        "dist/status.js",
+        "dist/try.d.ts",
+        "dist/try.d.ts.map",
+        "dist/try.js",
+        "dist/validation-composition.d.ts",
+        "dist/validation-composition.d.ts.map",
+        "dist/validation-composition.js",
+        "package.json"
+      ],
+      "fileCount": 32,
+      "expectedFiles": [
+        "README.md",
+        "dist/check.d.ts",
+        "dist/check.d.ts.map",
+        "dist/check.js",
+        "dist/graph-provider-client.d.ts",
+        "dist/graph-provider-client.d.ts.map",
+        "dist/graph-provider-client.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/init.d.ts",
+        "dist/init.d.ts.map",
+        "dist/init.js",
+        "dist/reporting.d.ts",
+        "dist/reporting.d.ts.map",
+        "dist/reporting.js",
+        "dist/router.d.ts",
+        "dist/router.d.ts.map",
+        "dist/router.js",
+        "dist/scan.d.ts",
+        "dist/scan.d.ts.map",
+        "dist/scan.js",
+        "dist/status.d.ts",
+        "dist/status.d.ts.map",
+        "dist/status.js",
+        "dist/try.d.ts",
+        "dist/try.d.ts.map",
+        "dist/try.js",
+        "dist/validation-composition.d.ts",
+        "dist/validation-composition.d.ts.map",
+        "dist/validation-composition.js",
+        "package.json"
+      ],
+      "expectedFileCount": 32,
+      "bins": {
+        "opcore": "dist/index.js"
+      },
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/lattice-cli",
+      "packageRoot": "packages/cli",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-cli",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {
+          "lattice": "dist/index.js"
+        },
+        "dependencies": {
+          "@the-open-engine/lattice-edit": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-graph": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation-rust": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation-typescript": "0.1.0-alpha.0",
+          "ts-morph": "^28.0.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-cli-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-cli-0.1.0-alpha.0.tgz",
+        "sha256": "b05924813e985235f383c994ceeb4633d0fb1058f7030e1a5492a7a003710998",
+        "integrity": "sha512-FB9Dfr9bxFBUOK2xq8WC1SoZmoTkbbqEkWwdjNgWjTKReWbtzRqN5KnsRXyKx9OwSvIEX6c45EUg7CGU9a46Pg==",
+        "shasum": "301915341b07d6f10e60638fa008f48a4baaa964"
+      },
+      "files": [
+        "README.md",
+        "dist/descriptor.d.ts",
+        "dist/descriptor.d.ts.map",
+        "dist/descriptor.js",
+        "dist/descriptors/lattice.managed-tool.json",
+        "dist/edit-composition.d.ts",
+        "dist/edit-composition.d.ts.map",
+        "dist/edit-composition.js",
+        "dist/graph-provider-client.d.ts",
+        "dist/graph-provider-client.d.ts.map",
+        "dist/graph-provider-client.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/inspect-adapter.d.ts",
+        "dist/inspect-adapter.d.ts.map",
+        "dist/inspect-adapter.js",
+        "dist/inspect-language-service.d.ts",
+        "dist/inspect-language-service.d.ts.map",
+        "dist/inspect-language-service.js",
+        "dist/manifest.d.ts",
+        "dist/manifest.d.ts.map",
+        "dist/manifest.js",
+        "dist/router.d.ts",
+        "dist/router.d.ts.map",
+        "dist/router.js",
+        "dist/validation-composition.d.ts",
+        "dist/validation-composition.d.ts.map",
+        "dist/validation-composition.js",
+        "package.json"
+      ],
+      "fileCount": 30,
+      "expectedFiles": [
+        "README.md",
+        "dist/descriptor.d.ts",
+        "dist/descriptor.d.ts.map",
+        "dist/descriptor.js",
+        "dist/descriptors/lattice.managed-tool.json",
+        "dist/edit-composition.d.ts",
+        "dist/edit-composition.d.ts.map",
+        "dist/edit-composition.js",
+        "dist/graph-provider-client.d.ts",
+        "dist/graph-provider-client.d.ts.map",
+        "dist/graph-provider-client.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/inspect-adapter.d.ts",
+        "dist/inspect-adapter.d.ts.map",
+        "dist/inspect-adapter.js",
+        "dist/inspect-language-service.d.ts",
+        "dist/inspect-language-service.d.ts.map",
+        "dist/inspect-language-service.js",
+        "dist/manifest.d.ts",
+        "dist/manifest.d.ts.map",
+        "dist/manifest.js",
+        "dist/router.d.ts",
+        "dist/router.d.ts.map",
+        "dist/router.js",
+        "dist/validation-composition.d.ts",
+        "dist/validation-composition.d.ts.map",
+        "dist/validation-composition.js",
+        "package.json"
+      ],
+      "expectedFileCount": 30,
+      "bins": {
+        "lattice": "dist/index.js"
+      },
+      "descriptorReferences": [
+        {
+          "id": "cli-entrypoint",
+          "packageName": "@the-open-engine/lattice-cli",
+          "path": "dist/index.js",
+          "type": "entrypoint",
+          "required": true
+        },
+        {
+          "id": "descriptor",
+          "packageName": "@the-open-engine/lattice-cli",
+          "path": "dist/descriptors/lattice.managed-tool.json",
+          "type": "descriptor",
+          "required": true
+        }
+      ],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/lattice-graph",
+      "packageRoot": "packages/graph",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-graph",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0"
+        },
+        "optionalDependencies": {
+          "@the-open-engine/opcore-graph-core-darwin-arm64": "0.1.0-alpha.0",
+          "@the-open-engine/opcore-graph-core-darwin-x64": "0.1.0-alpha.0",
+          "@the-open-engine/opcore-graph-core-linux-x64": "0.1.0-alpha.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-graph-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-graph-0.1.0-alpha.0.tgz",
+        "sha256": "b3c0d26e66d9ff66d62890c77411c540d98892cefa320291f783d106517de7d6",
+        "integrity": "sha512-nvZrFOOVfJMaZPoo96iYzX+rwphq6ljiuvvPXtFoO0Kn2PcNfYs3mr9AdLX9ntlGqKtUmTnYN3uXgYWo0YGnig==",
+        "shasum": "a603ab73d5d731f81de3b9e5f7ace42417517fb7"
+      },
+      "files": [
+        "README.md",
+        "dist/artifact.d.ts",
+        "dist/artifact.d.ts.map",
+        "dist/artifact.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/native-targets.d.ts",
+        "dist/native-targets.d.ts.map",
+        "dist/native-targets.js",
+        "dist/serve.d.ts",
+        "dist/serve.d.ts.map",
+        "dist/serve.js",
+        "dist/sidecar.d.ts",
+        "dist/sidecar.d.ts.map",
+        "dist/sidecar.js",
+        "package.json"
+      ],
+      "fileCount": 17,
+      "expectedFiles": [
+        "README.md",
+        "dist/artifact.d.ts",
+        "dist/artifact.d.ts.map",
+        "dist/artifact.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/native-targets.d.ts",
+        "dist/native-targets.d.ts.map",
+        "dist/native-targets.js",
+        "dist/serve.d.ts",
+        "dist/serve.d.ts.map",
+        "dist/serve.js",
+        "dist/sidecar.d.ts",
+        "dist/sidecar.d.ts.map",
+        "dist/sidecar.js",
+        "package.json"
+      ],
+      "expectedFileCount": 17,
+      "bins": {},
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+      "packageRoot": "packages/opcore-graph-core-darwin-arm64",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/opcore-graph-core-darwin-arm64",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "files": [
+          "lattice-graph-core",
+          "lattice-graph-core.sha256",
+          "metadata.json",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {},
+        "os": [
+          "darwin"
+        ],
+        "cpu": [
+          "arm64"
+        ],
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-opcore-graph-core-darwin-arm64-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-opcore-graph-core-darwin-arm64-0.1.0-alpha.0.tgz",
+        "sha256": "ac6c9c61a0bcd799973d871a39d7d694a45875aefda34dfb83754df0dd4795ad",
+        "integrity": "sha512-fPlXmAkc+6TfjVz4EclFCREommnoh6aB9mjFzk+w5nyD0693DZEw+10Mc1B5kS9namHukXj13TAIoshCb3ddJA==",
+        "shasum": "23e534e904f240404ee60c52cf461806418fe43b"
+      },
+      "files": [
+        "README.md",
+        "lattice-graph-core",
+        "lattice-graph-core.sha256",
+        "metadata.json",
+        "package.json"
+      ],
+      "fileCount": 5,
+      "expectedFiles": [
+        "README.md",
+        "lattice-graph-core",
+        "lattice-graph-core.sha256",
+        "metadata.json",
+        "package.json"
+      ],
+      "expectedFileCount": 5,
+      "bins": {},
+      "descriptorReferences": [
+        {
+          "id": "graph-core-binary-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "lattice-graph-core",
+          "type": "native_binary",
+          "required": true,
+          "checksumRef": "graph-core-binary-sha256-darwin-arm64"
+        },
+        {
+          "id": "graph-core-metadata-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "metadata.json",
+          "type": "manifest",
+          "required": true
+        },
+        {
+          "id": "graph-core-checksum-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "lattice-graph-core.sha256",
+          "type": "checksum",
+          "required": true
+        }
+      ],
+      "nativeArtifacts": [
+        {
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "targetPlatform": "darwin-arm64",
+          "metadata": {
+            "artifactName": "lattice-graph-core",
+            "artifactVersion": "0.1.0-alpha.0",
+            "targetPlatform": "darwin-arm64",
+            "binaryPath": "lattice-graph-core",
+            "checksumPath": "lattice-graph-core.sha256",
+            "checksumSha256": "34bcd16b63011b1e360cf86457945d33749c18d71025f53c9937431c374691b4",
+            "buildProfile": "release"
+          },
+          "binaryPath": "lattice-graph-core",
+          "checksumPath": "lattice-graph-core.sha256",
+          "metadataPath": "metadata.json",
+          "binarySha256": "34bcd16b63011b1e360cf86457945d33749c18d71025f53c9937431c374691b4",
+          "checksumFileSha256": "985d073e1fc1de37585f179298a80cbc7bca739dba028283ceb211a26a4e626c",
+          "metadataSha256": "7962a876e5279b62a161346ff19620a1775e5b6c0374c71f48f531b7fdcb2073",
+          "descriptorArtifactId": "graph-core-binary-darwin-arm64",
+          "descriptorChecksumId": "graph-core-binary-sha256-darwin-arm64"
+        }
+      ]
+    },
+    {
+      "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+      "packageRoot": "packages/opcore-graph-core-darwin-x64",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/opcore-graph-core-darwin-x64",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "files": [
+          "lattice-graph-core",
+          "lattice-graph-core.sha256",
+          "metadata.json",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {},
+        "os": [
+          "darwin"
+        ],
+        "cpu": [
+          "x64"
+        ],
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-opcore-graph-core-darwin-x64-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-opcore-graph-core-darwin-x64-0.1.0-alpha.0.tgz",
+        "sha256": "f589d3df77bbbdeb24f29d4b7c3dcc36d79397441be9e1b2bcc8c59110d637e3",
+        "integrity": "sha512-0wXosy8wU7GpBuI+Jzr4m65EXnsANhdyQmW44jm6SKdr5FHtdLxqpZGCr/OL5IktwFUWK5OhR7UGjX3gVixOCg==",
+        "shasum": "dd26d9ab64da550e8c2800ab7c232dc7ae6af551"
+      },
+      "files": [
+        "README.md",
+        "lattice-graph-core",
+        "lattice-graph-core.sha256",
+        "metadata.json",
+        "package.json"
+      ],
+      "fileCount": 5,
+      "expectedFiles": [
+        "README.md",
+        "lattice-graph-core",
+        "lattice-graph-core.sha256",
+        "metadata.json",
+        "package.json"
+      ],
+      "expectedFileCount": 5,
+      "bins": {},
+      "descriptorReferences": [
+        {
+          "id": "graph-core-binary-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "lattice-graph-core",
+          "type": "native_binary",
+          "required": true,
+          "checksumRef": "graph-core-binary-sha256-darwin-x64"
+        },
+        {
+          "id": "graph-core-metadata-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "metadata.json",
+          "type": "manifest",
+          "required": true
+        },
+        {
+          "id": "graph-core-checksum-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "lattice-graph-core.sha256",
+          "type": "checksum",
+          "required": true
+        }
+      ],
+      "nativeArtifacts": [
+        {
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "targetPlatform": "darwin-x64",
+          "metadata": {
+            "artifactName": "lattice-graph-core",
+            "artifactVersion": "0.1.0-alpha.0",
+            "targetPlatform": "darwin-x64",
+            "binaryPath": "lattice-graph-core",
+            "checksumPath": "lattice-graph-core.sha256",
+            "checksumSha256": "6652d43eec8f39e7c1b930b92e032eb268d1e4263454a89614e0d8299fc3b4e7",
+            "buildProfile": "release"
+          },
+          "binaryPath": "lattice-graph-core",
+          "checksumPath": "lattice-graph-core.sha256",
+          "metadataPath": "metadata.json",
+          "binarySha256": "6652d43eec8f39e7c1b930b92e032eb268d1e4263454a89614e0d8299fc3b4e7",
+          "checksumFileSha256": "1dec7f16ea99ceb1f7c1c7798b2841b77328d7546ab7eef09e90c898f83eea74",
+          "metadataSha256": "090548988a137c9f3f900fb736f3ae1176a2fd438742975dcb3eba04f827f413",
+          "descriptorArtifactId": "graph-core-binary-darwin-x64",
+          "descriptorChecksumId": "graph-core-binary-sha256-darwin-x64"
+        }
+      ]
+    },
+    {
+      "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+      "packageRoot": "packages/opcore-graph-core-linux-x64",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/opcore-graph-core-linux-x64",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "files": [
+          "lattice-graph-core",
+          "lattice-graph-core.sha256",
+          "metadata.json",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {},
+        "os": [
+          "linux"
+        ],
+        "cpu": [
+          "x64"
+        ],
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-opcore-graph-core-linux-x64-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-opcore-graph-core-linux-x64-0.1.0-alpha.0.tgz",
+        "sha256": "02fb3bc51d95c5f3f6c7940c9695c7061f113542542a454db783cad2b8b72e41",
+        "integrity": "sha512-VIOI9SkcbEqxM9/YgTJIerVPhfAV3aNUGNhHxtlsL+LxTso6qzwXYdsg0Nq7NDm3CqgNKp0Ezy4hbLCIl1gFDw==",
+        "shasum": "82a208620b2b9169757b83b73da08352f621a54d"
+      },
+      "files": [
+        "README.md",
+        "lattice-graph-core",
+        "lattice-graph-core.sha256",
+        "metadata.json",
+        "package.json"
+      ],
+      "fileCount": 5,
+      "expectedFiles": [
+        "README.md",
+        "lattice-graph-core",
+        "lattice-graph-core.sha256",
+        "metadata.json",
+        "package.json"
+      ],
+      "expectedFileCount": 5,
+      "bins": {},
+      "descriptorReferences": [
+        {
+          "id": "graph-core-binary-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "lattice-graph-core",
+          "type": "native_binary",
+          "required": true,
+          "checksumRef": "graph-core-binary-sha256-linux-x64"
+        },
+        {
+          "id": "graph-core-metadata-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "metadata.json",
+          "type": "manifest",
+          "required": true
+        },
+        {
+          "id": "graph-core-checksum-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "lattice-graph-core.sha256",
+          "type": "checksum",
+          "required": true
+        }
+      ],
+      "nativeArtifacts": [
+        {
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "targetPlatform": "linux-x64",
+          "metadata": {
+            "artifactName": "lattice-graph-core",
+            "artifactVersion": "0.1.0-alpha.0",
+            "targetPlatform": "linux-x64",
+            "binaryPath": "lattice-graph-core",
+            "checksumPath": "lattice-graph-core.sha256",
+            "checksumSha256": "4654c6ba6383886e759fe3c805ec8c0df3b31d2e1db9d5c18626de6b2cfe758a",
+            "buildProfile": "release"
+          },
+          "binaryPath": "lattice-graph-core",
+          "checksumPath": "lattice-graph-core.sha256",
+          "metadataPath": "metadata.json",
+          "binarySha256": "4654c6ba6383886e759fe3c805ec8c0df3b31d2e1db9d5c18626de6b2cfe758a",
+          "checksumFileSha256": "d2b196e6c2bd94f803d77741de855779347b2704634b5ca06a2ab0ad4fe3d14e",
+          "metadataSha256": "bbe9341144b043ae9828d7c75fee71696281b9280bf3443831c61ef2cf56a07f",
+          "descriptorArtifactId": "graph-core-binary-linux-x64",
+          "descriptorChecksumId": "graph-core-binary-sha256-linux-x64"
+        }
+      ]
+    },
+    {
+      "packageName": "@the-open-engine/lattice-edit",
+      "packageRoot": "packages/edit",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-edit",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0",
+          "ts-morph": "^28.0.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-edit-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-edit-0.1.0-alpha.0.tgz",
+        "sha256": "43048ec715740e326b9fb58e5bbc57eca75aa0d32ce1a49b08d1a5ea603e0104",
+        "integrity": "sha512-GzWoPLzGueTrLOLgZYe+PfS6DeYJT0Ob3lNxZbg4znIjPes8J3NTol5oa+NM5KbU6NMLV0jWABqAJRyClrgg0A==",
+        "shasum": "4e230041f87cf0dfb6842fe6734ffe2d4cda9663"
+      },
+      "files": [
+        "README.md",
+        "dist/atomic-writer.d.ts",
+        "dist/atomic-writer.d.ts.map",
+        "dist/atomic-writer.js",
+        "dist/codex-patch-parser.d.ts",
+        "dist/codex-patch-parser.d.ts.map",
+        "dist/codex-patch-parser.js",
+        "dist/codex-patch-planner.d.ts",
+        "dist/codex-patch-planner.d.ts.map",
+        "dist/codex-patch-planner.js",
+        "dist/command-adapter.d.ts",
+        "dist/command-adapter.d.ts.map",
+        "dist/command-adapter.js",
+        "dist/command-parser.d.ts",
+        "dist/command-parser.d.ts.map",
+        "dist/command-parser.js",
+        "dist/content-policy.d.ts",
+        "dist/content-policy.d.ts.map",
+        "dist/content-policy.js",
+        "dist/hash.d.ts",
+        "dist/hash.d.ts.map",
+        "dist/hash.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/language-service.d.ts",
+        "dist/language-service.d.ts.map",
+        "dist/language-service.js",
+        "dist/operations.d.ts",
+        "dist/operations.d.ts.map",
+        "dist/operations.js",
+        "dist/patch-parser.d.ts",
+        "dist/patch-parser.d.ts.map",
+        "dist/patch-parser.js",
+        "dist/patch-tree-command.d.ts",
+        "dist/patch-tree-command.d.ts.map",
+        "dist/patch-tree-command.js",
+        "dist/path-policy.d.ts",
+        "dist/path-policy.d.ts.map",
+        "dist/path-policy.js",
+        "dist/planner.d.ts",
+        "dist/planner.d.ts.map",
+        "dist/planner.js",
+        "dist/symbol-command.d.ts",
+        "dist/symbol-command.d.ts.map",
+        "dist/symbol-command.js",
+        "dist/symbol-graph.d.ts",
+        "dist/symbol-graph.d.ts.map",
+        "dist/symbol-graph.js",
+        "dist/symbol-preview.d.ts",
+        "dist/symbol-preview.d.ts.map",
+        "dist/symbol-preview.js",
+        "dist/symbol-requests.d.ts",
+        "dist/symbol-requests.d.ts.map",
+        "dist/symbol-requests.js",
+        "dist/tree-planner.d.ts",
+        "dist/tree-planner.d.ts.map",
+        "dist/tree-planner.js",
+        "dist/validated-apply.d.ts",
+        "dist/validated-apply.d.ts.map",
+        "dist/validated-apply.js",
+        "dist/validation-request.d.ts",
+        "dist/validation-request.d.ts.map",
+        "dist/validation-request.js",
+        "dist/validation.d.ts",
+        "dist/validation.d.ts.map",
+        "dist/validation.js",
+        "dist/workspace.d.ts",
+        "dist/workspace.d.ts.map",
+        "dist/workspace.js",
+        "package.json"
+      ],
+      "fileCount": 71,
+      "expectedFiles": [
+        "README.md",
+        "dist/atomic-writer.d.ts",
+        "dist/atomic-writer.d.ts.map",
+        "dist/atomic-writer.js",
+        "dist/codex-patch-parser.d.ts",
+        "dist/codex-patch-parser.d.ts.map",
+        "dist/codex-patch-parser.js",
+        "dist/codex-patch-planner.d.ts",
+        "dist/codex-patch-planner.d.ts.map",
+        "dist/codex-patch-planner.js",
+        "dist/command-adapter.d.ts",
+        "dist/command-adapter.d.ts.map",
+        "dist/command-adapter.js",
+        "dist/command-parser.d.ts",
+        "dist/command-parser.d.ts.map",
+        "dist/command-parser.js",
+        "dist/content-policy.d.ts",
+        "dist/content-policy.d.ts.map",
+        "dist/content-policy.js",
+        "dist/hash.d.ts",
+        "dist/hash.d.ts.map",
+        "dist/hash.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/language-service.d.ts",
+        "dist/language-service.d.ts.map",
+        "dist/language-service.js",
+        "dist/operations.d.ts",
+        "dist/operations.d.ts.map",
+        "dist/operations.js",
+        "dist/patch-parser.d.ts",
+        "dist/patch-parser.d.ts.map",
+        "dist/patch-parser.js",
+        "dist/patch-tree-command.d.ts",
+        "dist/patch-tree-command.d.ts.map",
+        "dist/patch-tree-command.js",
+        "dist/path-policy.d.ts",
+        "dist/path-policy.d.ts.map",
+        "dist/path-policy.js",
+        "dist/planner.d.ts",
+        "dist/planner.d.ts.map",
+        "dist/planner.js",
+        "dist/symbol-command.d.ts",
+        "dist/symbol-command.d.ts.map",
+        "dist/symbol-command.js",
+        "dist/symbol-graph.d.ts",
+        "dist/symbol-graph.d.ts.map",
+        "dist/symbol-graph.js",
+        "dist/symbol-preview.d.ts",
+        "dist/symbol-preview.d.ts.map",
+        "dist/symbol-preview.js",
+        "dist/symbol-requests.d.ts",
+        "dist/symbol-requests.d.ts.map",
+        "dist/symbol-requests.js",
+        "dist/tree-planner.d.ts",
+        "dist/tree-planner.d.ts.map",
+        "dist/tree-planner.js",
+        "dist/validated-apply.d.ts",
+        "dist/validated-apply.d.ts.map",
+        "dist/validated-apply.js",
+        "dist/validation-request.d.ts",
+        "dist/validation-request.d.ts.map",
+        "dist/validation-request.js",
+        "dist/validation.d.ts",
+        "dist/validation.d.ts.map",
+        "dist/validation.js",
+        "dist/workspace.d.ts",
+        "dist/workspace.d.ts.map",
+        "dist/workspace.js",
+        "package.json"
+      ],
+      "expectedFileCount": 71,
+      "bins": {},
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/lattice-validation",
+      "packageRoot": "packages/validation",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-validation",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-validation-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-validation-0.1.0-alpha.0.tgz",
+        "sha256": "1c79b723abd731e75981c0f0811eb4904e521254cd4b945da5bc49f33ec975ad",
+        "integrity": "sha512-499+limc7R49oTo7++hFtpQCsxPnUt1Cp497qnAXB1jd7QkJfUxKyh3M8lP+LUSnbL9vgNJWRYsxPYgbOUVx8w==",
+        "shasum": "684c5cf5169af3c73f40ee5278c4d3db20f1c792"
+      },
+      "files": [
+        "README.md",
+        "dist/aggregation.d.ts",
+        "dist/aggregation.d.ts.map",
+        "dist/aggregation.js",
+        "dist/command-adapter.d.ts",
+        "dist/command-adapter.d.ts.map",
+        "dist/command-adapter.js",
+        "dist/command-options.d.ts",
+        "dist/command-options.d.ts.map",
+        "dist/command-options.js",
+        "dist/graph-client.d.ts",
+        "dist/graph-client.d.ts.map",
+        "dist/graph-client.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/overlays.d.ts",
+        "dist/overlays.d.ts.map",
+        "dist/overlays.js",
+        "dist/registry.d.ts",
+        "dist/registry.d.ts.map",
+        "dist/registry.js",
+        "dist/request.d.ts",
+        "dist/request.d.ts.map",
+        "dist/request.js",
+        "dist/runner.d.ts",
+        "dist/runner.d.ts.map",
+        "dist/runner.js",
+        "dist/scope.d.ts",
+        "dist/scope.d.ts.map",
+        "dist/scope.js",
+        "dist/status-payload.d.ts",
+        "dist/status-payload.d.ts.map",
+        "dist/status-payload.js",
+        "dist/workspace.d.ts",
+        "dist/workspace.d.ts.map",
+        "dist/workspace.js",
+        "package.json"
+      ],
+      "fileCount": 38,
+      "expectedFiles": [
+        "README.md",
+        "dist/aggregation.d.ts",
+        "dist/aggregation.d.ts.map",
+        "dist/aggregation.js",
+        "dist/command-adapter.d.ts",
+        "dist/command-adapter.d.ts.map",
+        "dist/command-adapter.js",
+        "dist/command-options.d.ts",
+        "dist/command-options.d.ts.map",
+        "dist/command-options.js",
+        "dist/graph-client.d.ts",
+        "dist/graph-client.d.ts.map",
+        "dist/graph-client.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/overlays.d.ts",
+        "dist/overlays.d.ts.map",
+        "dist/overlays.js",
+        "dist/registry.d.ts",
+        "dist/registry.d.ts.map",
+        "dist/registry.js",
+        "dist/request.d.ts",
+        "dist/request.d.ts.map",
+        "dist/request.js",
+        "dist/runner.d.ts",
+        "dist/runner.d.ts.map",
+        "dist/runner.js",
+        "dist/scope.d.ts",
+        "dist/scope.d.ts.map",
+        "dist/scope.js",
+        "dist/status-payload.d.ts",
+        "dist/status-payload.d.ts.map",
+        "dist/status-payload.js",
+        "dist/workspace.d.ts",
+        "dist/workspace.d.ts.map",
+        "dist/workspace.js",
+        "package.json"
+      ],
+      "expectedFileCount": 38,
+      "bins": {},
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/lattice-validation-rust",
+      "packageRoot": "packages/validation-rust",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-validation-rust",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation": "0.1.0-alpha.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-validation-rust-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-validation-rust-0.1.0-alpha.0.tgz",
+        "sha256": "be71165c1846d1f9d35eb1b3557b7a16386ced45d47ac8a82341dac0ed599d14",
+        "integrity": "sha512-za5D9Jyo56iJWY6SiIs/845S4wygxgzATIxi/YON3J4yuwvzpnaK5haWD+fWiHMM5vhvIYWRJCBL6u5tPYVylQ==",
+        "shasum": "46d37154b88be6cc49c8c490587a2b6253703f81"
+      },
+      "files": [
+        "README.md",
+        "dist/cargo-check.d.ts",
+        "dist/cargo-check.d.ts.map",
+        "dist/cargo-check.js",
+        "dist/cargo-metadata.d.ts",
+        "dist/cargo-metadata.d.ts.map",
+        "dist/cargo-metadata.js",
+        "dist/check-constants.d.ts",
+        "dist/check-constants.d.ts.map",
+        "dist/check-constants.js",
+        "dist/check-ids.d.ts",
+        "dist/check-ids.d.ts.map",
+        "dist/check-ids.js",
+        "dist/diagnostics.d.ts",
+        "dist/diagnostics.d.ts.map",
+        "dist/diagnostics.js",
+        "dist/file-length-check.d.ts",
+        "dist/file-length-check.d.ts.map",
+        "dist/file-length-check.js",
+        "dist/fmt-check.d.ts",
+        "dist/fmt-check.d.ts.map",
+        "dist/fmt-check.js",
+        "dist/function-metrics-check.d.ts",
+        "dist/function-metrics-check.d.ts.map",
+        "dist/function-metrics-check.js",
+        "dist/import-graph-check.d.ts",
+        "dist/import-graph-check.d.ts.map",
+        "dist/import-graph-check.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/materialize.d.ts",
+        "dist/materialize.d.ts.map",
+        "dist/materialize.js",
+        "dist/process.d.ts",
+        "dist/process.d.ts.map",
+        "dist/process.js",
+        "dist/retained-compatibility.d.ts",
+        "dist/retained-compatibility.d.ts.map",
+        "dist/retained-compatibility.js",
+        "dist/source-files.d.ts",
+        "dist/source-files.d.ts.map",
+        "dist/source-files.js",
+        "dist/source-hygiene-check.d.ts",
+        "dist/source-hygiene-check.d.ts.map",
+        "dist/source-hygiene-check.js",
+        "dist/toolchain.d.ts",
+        "dist/toolchain.d.ts.map",
+        "dist/toolchain.js",
+        "dist/unused-deps-check.d.ts",
+        "dist/unused-deps-check.d.ts.map",
+        "dist/unused-deps-check.js",
+        "package.json"
+      ],
+      "fileCount": 53,
+      "expectedFiles": [
+        "README.md",
+        "dist/cargo-check.d.ts",
+        "dist/cargo-check.d.ts.map",
+        "dist/cargo-check.js",
+        "dist/cargo-metadata.d.ts",
+        "dist/cargo-metadata.d.ts.map",
+        "dist/cargo-metadata.js",
+        "dist/check-constants.d.ts",
+        "dist/check-constants.d.ts.map",
+        "dist/check-constants.js",
+        "dist/check-ids.d.ts",
+        "dist/check-ids.d.ts.map",
+        "dist/check-ids.js",
+        "dist/diagnostics.d.ts",
+        "dist/diagnostics.d.ts.map",
+        "dist/diagnostics.js",
+        "dist/file-length-check.d.ts",
+        "dist/file-length-check.d.ts.map",
+        "dist/file-length-check.js",
+        "dist/fmt-check.d.ts",
+        "dist/fmt-check.d.ts.map",
+        "dist/fmt-check.js",
+        "dist/function-metrics-check.d.ts",
+        "dist/function-metrics-check.d.ts.map",
+        "dist/function-metrics-check.js",
+        "dist/import-graph-check.d.ts",
+        "dist/import-graph-check.d.ts.map",
+        "dist/import-graph-check.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/materialize.d.ts",
+        "dist/materialize.d.ts.map",
+        "dist/materialize.js",
+        "dist/process.d.ts",
+        "dist/process.d.ts.map",
+        "dist/process.js",
+        "dist/retained-compatibility.d.ts",
+        "dist/retained-compatibility.d.ts.map",
+        "dist/retained-compatibility.js",
+        "dist/source-files.d.ts",
+        "dist/source-files.d.ts.map",
+        "dist/source-files.js",
+        "dist/source-hygiene-check.d.ts",
+        "dist/source-hygiene-check.d.ts.map",
+        "dist/source-hygiene-check.js",
+        "dist/toolchain.d.ts",
+        "dist/toolchain.d.ts.map",
+        "dist/toolchain.js",
+        "dist/unused-deps-check.d.ts",
+        "dist/unused-deps-check.d.ts.map",
+        "dist/unused-deps-check.js",
+        "package.json"
+      ],
+      "expectedFileCount": 53,
+      "bins": {},
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/lattice-validation-typescript",
+      "packageRoot": "packages/validation-typescript",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/lattice-validation-typescript",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {},
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation": "0.1.0-alpha.0",
+          "typescript": "^5.9.3"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-lattice-validation-typescript-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-lattice-validation-typescript-0.1.0-alpha.0.tgz",
+        "sha256": "f56d255773f271c7574aab364e6de6e5f305c6a27c285945eca01e9b2e14d2d7",
+        "integrity": "sha512-6Hk/ih6PZjreU4TWSW1krX9i22y975jy2g2Lj8/DMtp1S9Ojob8HeBeVNe5gII1WIxo3lqUuJxqqa0i0VM7OpQ==",
+        "shasum": "ffbaae8daa785858cdda80310995836f60db2e71"
+      },
+      "files": [
+        "README.md",
+        "dist/check-constants.d.ts",
+        "dist/check-constants.d.ts.map",
+        "dist/check-constants.js",
+        "dist/check-ids.d.ts",
+        "dist/check-ids.d.ts.map",
+        "dist/check-ids.js",
+        "dist/compiler-host.d.ts",
+        "dist/compiler-host.d.ts.map",
+        "dist/compiler-host.js",
+        "dist/compiler-options.d.ts",
+        "dist/compiler-options.d.ts.map",
+        "dist/compiler-options.js",
+        "dist/dead-code-check.d.ts",
+        "dist/dead-code-check.d.ts.map",
+        "dist/dead-code-check.js",
+        "dist/diagnostics.d.ts",
+        "dist/diagnostics.d.ts.map",
+        "dist/diagnostics.js",
+        "dist/graph-requirements.d.ts",
+        "dist/graph-requirements.d.ts.map",
+        "dist/graph-requirements.js",
+        "dist/import-graph-check.d.ts",
+        "dist/import-graph-check.d.ts.map",
+        "dist/import-graph-check.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/relevant-tests-check.d.ts",
+        "dist/relevant-tests-check.d.ts.map",
+        "dist/relevant-tests-check.js",
+        "dist/source-files.d.ts",
+        "dist/source-files.d.ts.map",
+        "dist/source-files.js",
+        "dist/syntax-check.d.ts",
+        "dist/syntax-check.d.ts.map",
+        "dist/syntax-check.js",
+        "dist/type-check.d.ts",
+        "dist/type-check.d.ts.map",
+        "dist/type-check.js",
+        "package.json"
+      ],
+      "fileCount": 41,
+      "expectedFiles": [
+        "README.md",
+        "dist/check-constants.d.ts",
+        "dist/check-constants.d.ts.map",
+        "dist/check-constants.js",
+        "dist/check-ids.d.ts",
+        "dist/check-ids.d.ts.map",
+        "dist/check-ids.js",
+        "dist/compiler-host.d.ts",
+        "dist/compiler-host.d.ts.map",
+        "dist/compiler-host.js",
+        "dist/compiler-options.d.ts",
+        "dist/compiler-options.d.ts.map",
+        "dist/compiler-options.js",
+        "dist/dead-code-check.d.ts",
+        "dist/dead-code-check.d.ts.map",
+        "dist/dead-code-check.js",
+        "dist/diagnostics.d.ts",
+        "dist/diagnostics.d.ts.map",
+        "dist/diagnostics.js",
+        "dist/graph-requirements.d.ts",
+        "dist/graph-requirements.d.ts.map",
+        "dist/graph-requirements.js",
+        "dist/import-graph-check.d.ts",
+        "dist/import-graph-check.d.ts.map",
+        "dist/import-graph-check.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/relevant-tests-check.d.ts",
+        "dist/relevant-tests-check.d.ts.map",
+        "dist/relevant-tests-check.js",
+        "dist/source-files.d.ts",
+        "dist/source-files.d.ts.map",
+        "dist/source-files.js",
+        "dist/syntax-check.d.ts",
+        "dist/syntax-check.d.ts.map",
+        "dist/syntax-check.js",
+        "dist/type-check.d.ts",
+        "dist/type-check.d.ts.map",
+        "dist/type-check.js",
+        "package.json"
+      ],
+      "expectedFileCount": 41,
+      "bins": {},
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    },
+    {
+      "packageName": "@the-open-engine/opcore-asp-provider",
+      "packageRoot": "packages/asp-provider",
+      "version": "0.1.0-alpha.0",
+      "manifest": {
+        "name": "@the-open-engine/opcore-asp-provider",
+        "version": "0.1.0-alpha.0",
+        "license": "MIT",
+        "main": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "files": [
+          "dist",
+          "README.md"
+        ],
+        "bins": {
+          "opcore-asp-provider": "dist/index.js"
+        },
+        "dependencies": {
+          "@the-open-engine/lattice-contracts": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-graph": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation-rust": "0.1.0-alpha.0",
+          "@the-open-engine/lattice-validation-typescript": "0.1.0-alpha.0"
+        },
+        "bundledDependencies": []
+      },
+      "tarball": {
+        "filename": "the-open-engine-opcore-asp-provider-0.1.0-alpha.0.tgz",
+        "path": ".lattice/release/packages/the-open-engine-opcore-asp-provider-0.1.0-alpha.0.tgz",
+        "sha256": "9367e33f76b7970fc40b9c1159e147467172e85fe10f2fd9575f9a3ee806d624",
+        "integrity": "sha512-Aa4PE70XHwFruy7bxRFZLGeFkMlGo+obrNBFqZdqaB7Ipk1CsEPhGpY/Xnty0neKEW8wWSxT3+BiTy1Sb0uacA==",
+        "shasum": "ea0f3322570ec51222eba469fafba5c87585f8db"
+      },
+      "files": [
+        "README.md",
+        "dist/digests.d.ts",
+        "dist/digests.d.ts.map",
+        "dist/digests.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/json-rpc.d.ts",
+        "dist/json-rpc.d.ts.map",
+        "dist/json-rpc.js",
+        "dist/manifest.d.ts",
+        "dist/manifest.d.ts.map",
+        "dist/manifest.js",
+        "dist/manifests/opcore-asp-provider.provisional.json",
+        "dist/mapping.d.ts",
+        "dist/mapping.d.ts.map",
+        "dist/mapping.js",
+        "dist/protocol.d.ts",
+        "dist/protocol.d.ts.map",
+        "dist/protocol.js",
+        "dist/validation-composition.d.ts",
+        "dist/validation-composition.d.ts.map",
+        "dist/validation-composition.js",
+        "dist/workspace.d.ts",
+        "dist/workspace.d.ts.map",
+        "dist/workspace.js",
+        "package.json"
+      ],
+      "fileCount": 27,
+      "expectedFiles": [
+        "README.md",
+        "dist/digests.d.ts",
+        "dist/digests.d.ts.map",
+        "dist/digests.js",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/index.js",
+        "dist/json-rpc.d.ts",
+        "dist/json-rpc.d.ts.map",
+        "dist/json-rpc.js",
+        "dist/manifest.d.ts",
+        "dist/manifest.d.ts.map",
+        "dist/manifest.js",
+        "dist/manifests/opcore-asp-provider.provisional.json",
+        "dist/mapping.d.ts",
+        "dist/mapping.d.ts.map",
+        "dist/mapping.js",
+        "dist/protocol.d.ts",
+        "dist/protocol.d.ts.map",
+        "dist/protocol.js",
+        "dist/validation-composition.d.ts",
+        "dist/validation-composition.d.ts.map",
+        "dist/validation-composition.js",
+        "dist/workspace.d.ts",
+        "dist/workspace.d.ts.map",
+        "dist/workspace.js",
+        "package.json"
+      ],
+      "expectedFileCount": 27,
+      "bins": {
+        "opcore-asp-provider": "dist/index.js"
+      },
+      "descriptorReferences": [],
+      "nativeArtifacts": []
+    }
+  ],
+  "descriptor": {
+    "path": "packages/cli/dist/descriptors/lattice.managed-tool.json",
+    "packageName": "@the-open-engine/lattice-cli",
+    "checksumSha256": "013196fc075e784d3be4c0e7d5d9a1535b65a68a3d1ad7b97b0933fd1db43720",
+    "descriptor": {
+      "schemaVersion": 1,
+      "descriptorKind": "aggregate_lattice",
+      "aggregateIdentity": {
+        "name": "lattice",
+        "releaseLine": "lattice",
+        "packageName": "@the-open-engine/lattice-cli",
+        "version": "0.1.0-alpha.0"
+      },
+      "packageIdentity": {
+        "packageName": "@the-open-engine/lattice-cli",
+        "artifactName": "@the-open-engine/lattice-cli",
+        "version": "0.1.0-alpha.0"
+      },
+      "entrypoints": [
+        {
+          "bin": "lattice",
+          "packageName": "@the-open-engine/lattice-cli",
+          "path": "dist/index.js",
+          "command": [
+            "lattice"
+          ]
+        }
+      ],
+      "commandGroups": [
+        {
+          "name": "graph",
+          "canonicalCommand": [
+            "lattice",
+            "graph"
+          ],
+          "commands": [
+            "build",
+            "update",
+            "watch",
+            "status",
+            "query",
+            "serve",
+            "impact",
+            "review-context",
+            "detect-changes",
+            "search"
+          ],
+          "packageName": "@the-open-engine/lattice-graph"
+        },
+        {
+          "name": "inspect",
+          "canonicalCommand": [
+            "lattice",
+            "inspect"
+          ],
+          "commands": [
+            "symbols",
+            "definition",
+            "references",
+            "signature",
+            "implementations",
+            "search"
+          ],
+          "packageName": "@the-open-engine/lattice-cli"
+        },
+        {
+          "name": "edit",
+          "canonicalCommand": [
+            "lattice",
+            "edit"
+          ],
+          "commands": [
+            "exact",
+            "multi",
+            "search-replace",
+            "check",
+            "apply",
+            "patch",
+            "tree",
+            "rename",
+            "move",
+            "signature"
+          ],
+          "packageName": "@the-open-engine/lattice-edit"
+        },
+        {
+          "name": "check",
+          "canonicalCommand": [
+            "lattice",
+            "check"
+          ],
+          "commands": [
+            "files",
+            "staged",
+            "changed",
+            "tree",
+            "all",
+            "manifest"
+          ],
+          "packageName": "@the-open-engine/lattice-validation"
+        },
+        {
+          "name": "validate",
+          "canonicalCommand": [
+            "lattice",
+            "validate"
+          ],
+          "commands": [
+            "request",
+            "hypothetical",
+            "pre-write",
+            "manifest"
+          ],
+          "packageName": "@the-open-engine/lattice-validation"
+        },
+        {
+          "name": "status",
+          "canonicalCommand": [
+            "lattice",
+            "status"
+          ],
+          "commands": [
+            "status"
+          ],
+          "packageName": "@the-open-engine/lattice-cli"
+        },
+        {
+          "name": "doctor",
+          "canonicalCommand": [
+            "lattice",
+            "doctor"
+          ],
+          "commands": [
+            "doctor"
+          ],
+          "packageName": "@the-open-engine/lattice-cli"
+        }
+      ],
+      "healthProbes": [
+        {
+          "id": "status-json",
+          "command": [
+            "lattice",
+            "status",
+            "--json"
+          ],
+          "expectedExitCode": 0,
+          "output": "json"
+        },
+        {
+          "id": "doctor-json",
+          "command": [
+            "lattice",
+            "doctor",
+            "--json"
+          ],
+          "expectedExitCode": 0,
+          "output": "json"
+        },
+        {
+          "id": "graph-status-json",
+          "command": [
+            "lattice",
+            "graph",
+            "status",
+            "--json"
+          ],
+          "expectedExitCode": 0,
+          "output": "json"
+        },
+        {
+          "id": "check-manifest-json",
+          "command": [
+            "lattice",
+            "check",
+            "manifest",
+            "--json"
+          ],
+          "expectedExitCode": 0,
+          "output": "json"
+        },
+        {
+          "id": "validate-manifest-json",
+          "command": [
+            "lattice",
+            "validate",
+            "manifest",
+            "--json"
+          ],
+          "expectedExitCode": 0,
+          "output": "json"
+        }
+      ],
+      "capabilities": {
+        "graph": {
+          "provider": "lattice-graph",
+          "schemaVersion": 1,
+          "commands": [
+            "build",
+            "update",
+            "watch",
+            "status",
+            "query",
+            "impact",
+            "review-context",
+            "detect-changes",
+            "search",
+            "serve"
+          ],
+          "queryKinds": [
+            "nodes",
+            "edges",
+            "neighbors",
+            "symbols",
+            "impact",
+            "callers_of",
+            "callees_of",
+            "importers_of",
+            "imports_of",
+            "tests_for",
+            "children_of",
+            "file_summary",
+            "review_context",
+            "detect_changes",
+            "search"
+          ],
+          "daemonOperations": [
+            "ping",
+            "status",
+            "query",
+            "search",
+            "shutdown"
+          ],
+          "nativeArtifacts": [
+            {
+              "targetPlatform": "darwin-arm64",
+              "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+              "binaryPath": "lattice-graph-core",
+              "metadataPath": "metadata.json",
+              "checksumPath": "lattice-graph-core.sha256",
+              "artifactIds": {
+                "binaryArtifactId": "graph-core-binary-darwin-arm64",
+                "metadataArtifactId": "graph-core-metadata-darwin-arm64",
+                "checksumArtifactId": "graph-core-checksum-darwin-arm64",
+                "checksumId": "graph-core-binary-sha256-darwin-arm64"
+              }
+            },
+            {
+              "targetPlatform": "darwin-x64",
+              "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+              "binaryPath": "lattice-graph-core",
+              "metadataPath": "metadata.json",
+              "checksumPath": "lattice-graph-core.sha256",
+              "artifactIds": {
+                "binaryArtifactId": "graph-core-binary-darwin-x64",
+                "metadataArtifactId": "graph-core-metadata-darwin-x64",
+                "checksumArtifactId": "graph-core-checksum-darwin-x64",
+                "checksumId": "graph-core-binary-sha256-darwin-x64"
+              }
+            },
+            {
+              "targetPlatform": "linux-x64",
+              "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+              "binaryPath": "lattice-graph-core",
+              "metadataPath": "metadata.json",
+              "checksumPath": "lattice-graph-core.sha256",
+              "artifactIds": {
+                "binaryArtifactId": "graph-core-binary-linux-x64",
+                "metadataArtifactId": "graph-core-metadata-linux-x64",
+                "checksumArtifactId": "graph-core-checksum-linux-x64",
+                "checksumId": "graph-core-binary-sha256-linux-x64"
+              }
+            }
+          ]
+        },
+        "edit": {
+          "commands": [
+            "exact",
+            "multi",
+            "search-replace",
+            "patch",
+            "tree",
+            "rename",
+            "move",
+            "signature",
+            "check",
+            "apply"
+          ],
+          "safeEditModes": [
+            "exact",
+            "multi",
+            "search-replace",
+            "patch",
+            "tree"
+          ],
+          "symbolEditModes": [
+            "rename",
+            "move",
+            "signature"
+          ],
+          "validationRequiredForApply": true,
+          "dryRun": true
+        },
+        "validation": {
+          "checkRoutes": [
+            "files",
+            "staged",
+            "changed",
+            "tree",
+            "all",
+            "manifest"
+          ],
+          "validateRoutes": [
+            "request",
+            "hypothetical",
+            "pre-write",
+            "manifest"
+          ],
+          "scopeModes": [
+            "files",
+            "changed",
+            "staged",
+            "tree",
+            "all",
+            "repo",
+            "package"
+          ],
+          "graphModes": [
+            "optional",
+            "required"
+          ],
+          "hypothetical": true,
+          "statusSurfaces": [
+            "status",
+            "doctor"
+          ],
+          "checkIds": [
+            "typescript.syntax",
+            "typescript.types",
+            "typescript.import-graph",
+            "typescript.dead-code",
+            "typescript.relevant-tests",
+            "rust.source-hygiene",
+            "rust.fmt",
+            "rust.cargo-check",
+            "rust.clippy",
+            "rust.rustdoc",
+            "rust.import-graph",
+            "rust.dead-code",
+            "rust.unused-deps",
+            "rust.file-length",
+            "rust.function-metrics"
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "id": "cli-entrypoint",
+          "packageName": "@the-open-engine/lattice-cli",
+          "path": "dist/index.js",
+          "type": "entrypoint",
+          "required": true
+        },
+        {
+          "id": "descriptor",
+          "packageName": "@the-open-engine/lattice-cli",
+          "path": "dist/descriptors/lattice.managed-tool.json",
+          "type": "descriptor",
+          "required": true
+        },
+        {
+          "id": "contracts-schema",
+          "packageName": "@the-open-engine/lattice-contracts",
+          "path": "schemas/lattice-contracts.schema.json",
+          "type": "schema",
+          "required": true
+        },
+        {
+          "id": "graph-core-binary-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "lattice-graph-core",
+          "type": "native_binary",
+          "required": true,
+          "checksumRef": "graph-core-binary-sha256-darwin-arm64"
+        },
+        {
+          "id": "graph-core-metadata-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "metadata.json",
+          "type": "manifest",
+          "required": true
+        },
+        {
+          "id": "graph-core-checksum-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "lattice-graph-core.sha256",
+          "type": "checksum",
+          "required": true
+        },
+        {
+          "id": "graph-core-binary-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "lattice-graph-core",
+          "type": "native_binary",
+          "required": true,
+          "checksumRef": "graph-core-binary-sha256-darwin-x64"
+        },
+        {
+          "id": "graph-core-metadata-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "metadata.json",
+          "type": "manifest",
+          "required": true
+        },
+        {
+          "id": "graph-core-checksum-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "lattice-graph-core.sha256",
+          "type": "checksum",
+          "required": true
+        },
+        {
+          "id": "graph-core-binary-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "lattice-graph-core",
+          "type": "native_binary",
+          "required": true,
+          "checksumRef": "graph-core-binary-sha256-linux-x64"
+        },
+        {
+          "id": "graph-core-metadata-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "metadata.json",
+          "type": "manifest",
+          "required": true
+        },
+        {
+          "id": "graph-core-checksum-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "lattice-graph-core.sha256",
+          "type": "checksum",
+          "required": true
+        }
+      ],
+      "checksums": [
+        {
+          "id": "graph-core-binary-sha256-darwin-arm64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+          "path": "lattice-graph-core.sha256",
+          "algorithm": "sha256",
+          "artifactRef": "graph-core-binary-darwin-arm64",
+          "required": true
+        },
+        {
+          "id": "graph-core-binary-sha256-darwin-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+          "path": "lattice-graph-core.sha256",
+          "algorithm": "sha256",
+          "artifactRef": "graph-core-binary-darwin-x64",
+          "required": true
+        },
+        {
+          "id": "graph-core-binary-sha256-linux-x64",
+          "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+          "path": "lattice-graph-core.sha256",
+          "algorithm": "sha256",
+          "artifactRef": "graph-core-binary-linux-x64",
+          "required": true
+        }
+      ],
+      "provenanceHooks": [
+        {
+          "id": "pack-check",
+          "command": [
+            "npm",
+            "run",
+            "pack:check"
+          ],
+          "expectedExitCode": 0
+        },
+        {
+          "id": "provenance-check",
+          "command": [
+            "npm",
+            "run",
+            "provenance:check"
+          ],
+          "expectedExitCode": 0
+        }
+      ],
+      "optionalSurfaces": [
+        {
+          "issue": "#13",
+          "id": "coverage",
+          "classification": "deferred",
+          "status": "deferred"
+        },
+        {
+          "issue": "#14",
+          "id": "flows",
+          "classification": "optional",
+          "status": "deferred"
+        },
+        {
+          "issue": "#15",
+          "id": "communities",
+          "classification": "optional",
+          "status": "deferred"
+        },
+        {
+          "issue": "#16",
+          "id": "read_only_suggestions",
+          "classification": "supporting",
+          "status": "deferred"
+        }
+      ]
+    },
+    "commandGroups": [
+      {
+        "name": "graph",
+        "canonicalCommand": [
+          "lattice",
+          "graph"
+        ],
+        "packageName": "@the-open-engine/lattice-graph"
+      },
+      {
+        "name": "inspect",
+        "canonicalCommand": [
+          "lattice",
+          "inspect"
+        ],
+        "packageName": "@the-open-engine/lattice-cli"
+      },
+      {
+        "name": "edit",
+        "canonicalCommand": [
+          "lattice",
+          "edit"
+        ],
+        "packageName": "@the-open-engine/lattice-edit"
+      },
+      {
+        "name": "check",
+        "canonicalCommand": [
+          "lattice",
+          "check"
+        ],
+        "packageName": "@the-open-engine/lattice-validation"
+      },
+      {
+        "name": "validate",
+        "canonicalCommand": [
+          "lattice",
+          "validate"
+        ],
+        "packageName": "@the-open-engine/lattice-validation"
+      },
+      {
+        "name": "status",
+        "canonicalCommand": [
+          "lattice",
+          "status"
+        ],
+        "packageName": "@the-open-engine/lattice-cli"
+      },
+      {
+        "name": "doctor",
+        "canonicalCommand": [
+          "lattice",
+          "doctor"
+        ],
+        "packageName": "@the-open-engine/lattice-cli"
+      }
+    ],
+    "resolvedArtifacts": [
+      {
+        "id": "cli-entrypoint",
+        "packageName": "@the-open-engine/lattice-cli",
+        "path": "dist/index.js",
+        "type": "entrypoint",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "descriptor",
+        "packageName": "@the-open-engine/lattice-cli",
+        "path": "dist/descriptors/lattice.managed-tool.json",
+        "type": "descriptor",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "contracts-schema",
+        "packageName": "@the-open-engine/lattice-contracts",
+        "path": "schemas/lattice-contracts.schema.json",
+        "type": "schema",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "graph-core-binary-darwin-arm64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+        "path": "lattice-graph-core",
+        "type": "native_binary",
+        "required": true,
+        "packageFile": true,
+        "checksumRef": "graph-core-binary-sha256-darwin-arm64"
+      },
+      {
+        "id": "graph-core-metadata-darwin-arm64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+        "path": "metadata.json",
+        "type": "manifest",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "graph-core-checksum-darwin-arm64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+        "path": "lattice-graph-core.sha256",
+        "type": "checksum",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "graph-core-binary-darwin-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+        "path": "lattice-graph-core",
+        "type": "native_binary",
+        "required": true,
+        "packageFile": true,
+        "checksumRef": "graph-core-binary-sha256-darwin-x64"
+      },
+      {
+        "id": "graph-core-metadata-darwin-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+        "path": "metadata.json",
+        "type": "manifest",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "graph-core-checksum-darwin-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+        "path": "lattice-graph-core.sha256",
+        "type": "checksum",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "graph-core-binary-linux-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+        "path": "lattice-graph-core",
+        "type": "native_binary",
+        "required": true,
+        "packageFile": true,
+        "checksumRef": "graph-core-binary-sha256-linux-x64"
+      },
+      {
+        "id": "graph-core-metadata-linux-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+        "path": "metadata.json",
+        "type": "manifest",
+        "required": true,
+        "packageFile": true
+      },
+      {
+        "id": "graph-core-checksum-linux-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+        "path": "lattice-graph-core.sha256",
+        "type": "checksum",
+        "required": true,
+        "packageFile": true
+      }
+    ],
+    "resolvedChecksums": [
+      {
+        "id": "graph-core-binary-sha256-darwin-arm64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+        "path": "lattice-graph-core.sha256",
+        "algorithm": "sha256",
+        "artifactRef": "graph-core-binary-darwin-arm64",
+        "required": true,
+        "packageFile": true,
+        "value": "34bcd16b63011b1e360cf86457945d33749c18d71025f53c9937431c374691b4"
+      },
+      {
+        "id": "graph-core-binary-sha256-darwin-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+        "path": "lattice-graph-core.sha256",
+        "algorithm": "sha256",
+        "artifactRef": "graph-core-binary-darwin-x64",
+        "required": true,
+        "packageFile": true,
+        "value": "6652d43eec8f39e7c1b930b92e032eb268d1e4263454a89614e0d8299fc3b4e7"
+      },
+      {
+        "id": "graph-core-binary-sha256-linux-x64",
+        "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+        "path": "lattice-graph-core.sha256",
+        "algorithm": "sha256",
+        "artifactRef": "graph-core-binary-linux-x64",
+        "required": true,
+        "packageFile": true,
+        "value": "4654c6ba6383886e759fe3c805ec8c0df3b31d2e1db9d5c18626de6b2cfe758a"
+      }
+    ]
+  },
+  "nativeArtifacts": [
+    {
+      "packageName": "@the-open-engine/opcore-graph-core-darwin-arm64",
+      "targetPlatform": "darwin-arm64",
+      "metadata": {
+        "artifactName": "lattice-graph-core",
+        "artifactVersion": "0.1.0-alpha.0",
+        "targetPlatform": "darwin-arm64",
+        "binaryPath": "lattice-graph-core",
+        "checksumPath": "lattice-graph-core.sha256",
+        "checksumSha256": "34bcd16b63011b1e360cf86457945d33749c18d71025f53c9937431c374691b4",
+        "buildProfile": "release"
+      },
+      "binaryPath": "lattice-graph-core",
+      "checksumPath": "lattice-graph-core.sha256",
+      "metadataPath": "metadata.json",
+      "binarySha256": "34bcd16b63011b1e360cf86457945d33749c18d71025f53c9937431c374691b4",
+      "checksumFileSha256": "985d073e1fc1de37585f179298a80cbc7bca739dba028283ceb211a26a4e626c",
+      "metadataSha256": "7962a876e5279b62a161346ff19620a1775e5b6c0374c71f48f531b7fdcb2073",
+      "descriptorArtifactId": "graph-core-binary-darwin-arm64",
+      "descriptorChecksumId": "graph-core-binary-sha256-darwin-arm64"
+    },
+    {
+      "packageName": "@the-open-engine/opcore-graph-core-darwin-x64",
+      "targetPlatform": "darwin-x64",
+      "metadata": {
+        "artifactName": "lattice-graph-core",
+        "artifactVersion": "0.1.0-alpha.0",
+        "targetPlatform": "darwin-x64",
+        "binaryPath": "lattice-graph-core",
+        "checksumPath": "lattice-graph-core.sha256",
+        "checksumSha256": "6652d43eec8f39e7c1b930b92e032eb268d1e4263454a89614e0d8299fc3b4e7",
+        "buildProfile": "release"
+      },
+      "binaryPath": "lattice-graph-core",
+      "checksumPath": "lattice-graph-core.sha256",
+      "metadataPath": "metadata.json",
+      "binarySha256": "6652d43eec8f39e7c1b930b92e032eb268d1e4263454a89614e0d8299fc3b4e7",
+      "checksumFileSha256": "1dec7f16ea99ceb1f7c1c7798b2841b77328d7546ab7eef09e90c898f83eea74",
+      "metadataSha256": "090548988a137c9f3f900fb736f3ae1176a2fd438742975dcb3eba04f827f413",
+      "descriptorArtifactId": "graph-core-binary-darwin-x64",
+      "descriptorChecksumId": "graph-core-binary-sha256-darwin-x64"
+    },
+    {
+      "packageName": "@the-open-engine/opcore-graph-core-linux-x64",
+      "targetPlatform": "linux-x64",
+      "metadata": {
+        "artifactName": "lattice-graph-core",
+        "artifactVersion": "0.1.0-alpha.0",
+        "targetPlatform": "linux-x64",
+        "binaryPath": "lattice-graph-core",
+        "checksumPath": "lattice-graph-core.sha256",
+        "checksumSha256": "4654c6ba6383886e759fe3c805ec8c0df3b31d2e1db9d5c18626de6b2cfe758a",
+        "buildProfile": "release"
+      },
+      "binaryPath": "lattice-graph-core",
+      "checksumPath": "lattice-graph-core.sha256",
+      "metadataPath": "metadata.json",
+      "binarySha256": "4654c6ba6383886e759fe3c805ec8c0df3b31d2e1db9d5c18626de6b2cfe758a",
+      "checksumFileSha256": "d2b196e6c2bd94f803d77741de855779347b2704634b5ca06a2ab0ad4fe3d14e",
+      "metadataSha256": "bbe9341144b043ae9828d7c75fee71696281b9280bf3443831c61ef2cf56a07f",
+      "descriptorArtifactId": "graph-core-binary-linux-x64",
+      "descriptorChecksumId": "graph-core-binary-sha256-linux-x64"
+    }
+  ],
+  "license": {
+    "reportPath": "docs/release/license-report.md",
+    "reportSha256": "1d3f69b3e24fe8f231b86070b6f0d69a6896a4431d0c23c8ee6dce0d9b58799b",
+    "productionDependencyCount": 11,
+    "bundledDependencyCount": 0,
+    "workspacePackageCount": 12,
+    "unresolvedLicenseCount": 0,
+    "packages": [
+      {
+        "name": "@ts-morph/common",
+        "version": "0.29.0",
+        "license": "MIT",
+        "source": "node_modules/@ts-morph/common",
+        "bundled": false
+      },
+      {
+        "name": "balanced-match",
+        "version": "4.0.4",
+        "license": "MIT",
+        "source": "node_modules/balanced-match",
+        "bundled": false
+      },
+      {
+        "name": "brace-expansion",
+        "version": "5.0.6",
+        "license": "MIT",
+        "source": "node_modules/brace-expansion",
+        "bundled": false
+      },
+      {
+        "name": "code-block-writer",
+        "version": "13.0.3",
+        "license": "MIT",
+        "source": "node_modules/code-block-writer",
+        "bundled": false
+      },
+      {
+        "name": "fdir",
+        "version": "6.5.0",
+        "license": "MIT",
+        "source": "node_modules/fdir",
+        "bundled": false
+      },
+      {
+        "name": "minimatch",
+        "version": "10.2.5",
+        "license": "BlueOak-1.0.0",
+        "source": "node_modules/minimatch",
+        "bundled": false
+      },
+      {
+        "name": "path-browserify",
+        "version": "1.0.1",
+        "license": "MIT",
+        "source": "node_modules/path-browserify",
+        "bundled": false
+      },
+      {
+        "name": "picomatch",
+        "version": "4.0.4",
+        "license": "MIT",
+        "source": "node_modules/picomatch",
+        "bundled": false
+      },
+      {
+        "name": "tinyglobby",
+        "version": "0.2.17",
+        "license": "MIT",
+        "source": "node_modules/tinyglobby",
+        "bundled": false
+      },
+      {
+        "name": "ts-morph",
+        "version": "28.0.0",
+        "license": "MIT",
+        "source": "node_modules/ts-morph",
+        "bundled": false
+      },
+      {
+        "name": "typescript",
+        "version": "5.9.3",
+        "license": "Apache-2.0",
+        "source": "node_modules/typescript",
+        "bundled": false
+      }
+    ]
+  },
+  "provenance": {
+    "reportPath": "docs/release/provenance-receipts.md",
+    "reportSha256": "8195ffea373f98c4bc6d12d6397a2cbc9693b19cec003c4609f3d4a9d652834a",
+    "scannedFileCount": 379,
+    "historyCommitCount": 137,
+    "findingCount": 0,
+    "findings": []
+  },
+  "secretHistory": {
+    "allowlistPath": "docs/release/secret-scan-allowlist.json",
+    "allowlistSha256": "7060c267c912e3156b87c646e3bc970eac1ac8bdd964cf0a794b83e6f1250614",
+    "currentTreeScannedFileCount": 378,
+    "gitHistoryScannedCommitCount": 137,
+    "findingCount": 0,
+    "findings": []
+  },
+  "reports": [
+    {
+      "id": "package-inspection",
+      "command": [
+        "node",
+        "scripts/generate-release-receipt.mjs",
+        "--inspect-packages-only"
+      ],
+      "status": "passed",
+      "exitCode": 0,
+      "path": "docs/release/release-receipt.json",
+      "summary": "npm pack package inspection passed"
+    },
+    {
+      "id": "license",
+      "command": [
+        "node",
+        "scripts/license-report.mjs",
+        "--json"
+      ],
+      "status": "passed",
+      "exitCode": 0,
+      "path": "docs/release/license-report.md",
+      "checksumSha256": "1d3f69b3e24fe8f231b86070b6f0d69a6896a4431d0c23c8ee6dce0d9b58799b",
+      "summary": "11 production dependencies, 0 unresolved"
+    },
+    {
+      "id": "provenance",
+      "command": [
+        "node",
+        "scripts/check-provenance.mjs",
+        "--json"
+      ],
+      "status": "passed",
+      "exitCode": 0,
+      "path": "docs/release/provenance-receipts.md",
+      "checksumSha256": "8195ffea373f98c4bc6d12d6397a2cbc9693b19cec003c4609f3d4a9d652834a",
+      "summary": "379 files, 137 commits scanned"
+    },
+    {
+      "id": "release-hygiene",
+      "command": [
+        "node",
+        "scripts/check-release-hygiene.mjs"
+      ],
+      "status": "passed",
+      "exitCode": 0,
+      "path": "docs/release/artifact-attestation.md",
+      "checksumSha256": "1eacf13c0ffc89796ffd042ad94928c784e0513a06fd51b04ecea27db08b524a",
+      "summary": "release hygiene check passed"
+    },
+    {
+      "id": "graph-release",
+      "command": [
+        "node",
+        "scripts/generate-graph-release-receipt.mjs",
+        "--json"
+      ],
+      "status": "passed",
+      "exitCode": 0,
+      "path": "docs/release/graph-release-receipt.json",
+      "checksumSha256": "3eb840352a74cee3ee9a44cb26b58dd05dacc016662bfa0973d20de5b280a183",
+      "summary": "graph release receipt #17 validated as input evidence"
+    },
+    {
+      "id": "secret-history",
+      "command": [
+        "node",
+        "scripts/generate-release-receipt.mjs",
+        "--scan-secrets-only"
+      ],
+      "status": "passed",
+      "exitCode": 0,
+      "path": "docs/release/secret-scan-allowlist.json",
+      "checksumSha256": "7060c267c912e3156b87c646e3bc970eac1ac8bdd964cf0a794b83e6f1250614",
+      "summary": "378 files, 137 commits scanned"
+    }
+  ],
+  "graphReleaseReceipt": {
+    "path": "docs/release/graph-release-receipt.json",
+    "issue": "#17",
+    "checksumSha256": "3eb840352a74cee3ee9a44cb26b58dd05dacc016662bfa0973d20de5b280a183"
+  }
+}

--- a/docs/release/release-receipt.summary.md
+++ b/docs/release/release-receipt.summary.md
@@ -1,0 +1,43 @@
+# Release Receipt Summary
+
+Maintainer release receipt for the Lattice alpha package gate.
+
+Machine receipt: docs/release/release-receipt.json
+Machine receipt SHA-256: c45da04b34794d940e4d1eefc8f4d1b18522318f4d750ba7df18267fe4929199
+
+Canonical command groups: graph, inspect, edit, check, validate, status, doctor
+Native graph artifacts: 3
+Secret/history findings: 0
+License unresolved count: 0
+
+## Packages
+
+| Package | Tarball | SHA-256 | Files |
+|---------|---------|---------|-------|
+| @the-open-engine/lattice-contracts | the-open-engine-lattice-contracts-0.1.0-alpha.0.tgz | 6801e8dda1ed82724bfa95d70ab7b7c4af4f87016a7471eb4cdfb425dda382b5 | 6 |
+| @the-open-engine/opcore | the-open-engine-opcore-0.1.0-alpha.0.tgz | 8d2858dad630606d3bd6984d9a13a547a04a2f469750172e031bb63577ac3e32 | 32 |
+| @the-open-engine/lattice-cli | the-open-engine-lattice-cli-0.1.0-alpha.0.tgz | b05924813e985235f383c994ceeb4633d0fb1058f7030e1a5492a7a003710998 | 30 |
+| @the-open-engine/lattice-graph | the-open-engine-lattice-graph-0.1.0-alpha.0.tgz | b3c0d26e66d9ff66d62890c77411c540d98892cefa320291f783d106517de7d6 | 17 |
+| @the-open-engine/opcore-graph-core-darwin-arm64 | the-open-engine-opcore-graph-core-darwin-arm64-0.1.0-alpha.0.tgz | ac6c9c61a0bcd799973d871a39d7d694a45875aefda34dfb83754df0dd4795ad | 5 |
+| @the-open-engine/opcore-graph-core-darwin-x64 | the-open-engine-opcore-graph-core-darwin-x64-0.1.0-alpha.0.tgz | f589d3df77bbbdeb24f29d4b7c3dcc36d79397441be9e1b2bcc8c59110d637e3 | 5 |
+| @the-open-engine/opcore-graph-core-linux-x64 | the-open-engine-opcore-graph-core-linux-x64-0.1.0-alpha.0.tgz | 02fb3bc51d95c5f3f6c7940c9695c7061f113542542a454db783cad2b8b72e41 | 5 |
+| @the-open-engine/lattice-edit | the-open-engine-lattice-edit-0.1.0-alpha.0.tgz | 43048ec715740e326b9fb58e5bbc57eca75aa0d32ce1a49b08d1a5ea603e0104 | 71 |
+| @the-open-engine/lattice-validation | the-open-engine-lattice-validation-0.1.0-alpha.0.tgz | 1c79b723abd731e75981c0f0811eb4904e521254cd4b945da5bc49f33ec975ad | 38 |
+| @the-open-engine/lattice-validation-rust | the-open-engine-lattice-validation-rust-0.1.0-alpha.0.tgz | be71165c1846d1f9d35eb1b3557b7a16386ced45d47ac8a82341dac0ed599d14 | 53 |
+| @the-open-engine/lattice-validation-typescript | the-open-engine-lattice-validation-typescript-0.1.0-alpha.0.tgz | f56d255773f271c7574aab364e6de6e5f305c6a27c285945eca01e9b2e14d2d7 | 41 |
+| @the-open-engine/opcore-asp-provider | the-open-engine-opcore-asp-provider-0.1.0-alpha.0.tgz | 9367e33f76b7970fc40b9c1159e147467172e85fe10f2fd9575f9a3ee806d624 | 27 |
+
+## Reports
+
+| Report | Status | SHA-256 | Summary |
+|--------|--------|---------|---------|
+| package-inspection | passed | n/a | npm pack package inspection passed |
+| license | passed | 1d3f69b3e24fe8f231b86070b6f0d69a6896a4431d0c23c8ee6dce0d9b58799b | 11 production dependencies, 0 unresolved |
+| provenance | passed | 8195ffea373f98c4bc6d12d6397a2cbc9693b19cec003c4609f3d4a9d652834a | 379 files, 137 commits scanned |
+| release-hygiene | passed | 1eacf13c0ffc89796ffd042ad94928c784e0513a06fd51b04ecea27db08b524a | release hygiene check passed |
+| graph-release | passed | 3eb840352a74cee3ee9a44cb26b58dd05dacc016662bfa0973d20de5b280a183 | graph release receipt #17 validated as input evidence |
+| secret-history | passed | 7060c267c912e3156b87c646e3bc970eac1ac8bdd964cf0a794b83e6f1250614 | 378 files, 137 commits scanned |
+
+Secret allowlist: docs/release/secret-scan-allowlist.json. Add entries only for reviewed false positives with path or commit scope, reviewer, reason, expiry, and optional fingerprint/kind narrowing.
+
+Publish status: this gate packs and verifies artifacts only. Publishing remains manual.


### PR DESCRIPTION
Closes #70

## Summary
- Restores the two release receipt docs deleted by PR #69's generated finisher commit.
- Leaves the intended #57 launch claim scrub source changes intact.

## Verification
- node scripts/check-release-hygiene.mjs
- npm ci && npm run build && node --test tests/release-receipt.test.mjs

## Constraint
Review PR only. Do not auto-merge without Tom approval.