### PR TITLE
fix(validation-rust): `rust.dead-code` preserves process.env while adding RUSTFLAGS

### DIFF
--- a/packages/validation-rust/src/cargo-check.ts
+++ b/packages/validation-rust/src/cargo-check.ts
@@ -211,11 +211,12 @@ async function runDeadCodeCheck(context: ValidationCheckContext, options: RustCo
     if (!metadata.ok) return metadataFailureResult(metadata);
     const packageScope = resolveCargoPackageScope(metadata.metadata, context.scope);
     if (!packageScope.ok) return metadataFailureResult(packageScope);
+    const baseEnv = options.env ?? process.env;
     const deadCodeOptions = {
       ...options,
       env: {
-        ...options.env,
-        RUSTFLAGS: [options.env?.RUSTFLAGS, "-Ddead_code"].filter(Boolean).join(" ")
+        ...baseEnv,
+        RUSTFLAGS: [baseEnv.RUSTFLAGS, "-Ddead_code"].filter(Boolean).join(" ")
       }
     };
     const commandArgs = scopedCargoArgs(["check", "--message-format=json", "--all-targets", "--all-features"], packageScope.member);

--- a/tests/helpers/validation-rust-fixtures.mjs
+++ b/tests/helpers/validation-rust-fixtures.mjs
@@ -7,7 +7,7 @@ import {
   createRustValidationChecks
 } from "../../packages/validation-rust/dist/index.js";
 
-export function runner({ files, env = process.env, packageFiles, timeoutMs } = {}) {
+export function runner({ files, env, packageFiles, timeoutMs } = {}) {
   const content = new Map(Object.entries(files ?? rustCrate()));
   return createValidationRunner({
     workspace: {
@@ -104,10 +104,11 @@ export function fakeCargoScript({
   udepsStatus = 0,
   udepsVersionStatus = 0,
   metadata = defaultCargoMetadata(),
-  logPath
+  logPath,
+  logEnvKeys = []
 } = {}) {
   const metadataJson = typeof metadata === "string" ? metadata : JSON.stringify(metadata);
-  const logLine = logPath === undefined ? "" : `printf '%s\\n' "$*" >> '${shellEscapeSingleQuoted(logPath)}'`;
+  const logLine = cargoInvocationLogLine(logPath, logEnvKeys);
   return [
     "#!/bin/sh",
     logLine,
@@ -217,6 +218,17 @@ function gitEnv() {
 
 function shellEscapeSingleQuoted(value) {
   return String(value).replaceAll("'", "'\\''");
+}
+
+function cargoInvocationLogLine(logPath, logEnvKeys) {
+  if (logPath === undefined) return "";
+  const escapedLogPath = shellEscapeSingleQuoted(logPath);
+  if (logEnvKeys.length === 0) return `printf '%s\\n' "$*" >> '${escapedLogPath}'`;
+  const envWrites = logEnvKeys.map((key) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) throw new Error(`Invalid env key for fake cargo log: ${key}`);
+    return `printf '\\t%s=%s' '${shellEscapeSingleQuoted(key)}' "$${key}" >> '${escapedLogPath}'`;
+  });
+  return [`printf '%s' "$*" >> '${escapedLogPath}'`, ...envWrites, `printf '\\n' >> '${escapedLogPath}'`].join("\n");
 }
 
 function writeExecutable(path, content) {

--- a/tests/validation-rust.test.mjs
+++ b/tests/validation-rust.test.mjs
@@ -1082,12 +1082,16 @@ const rustCheckIds = [
   it("combines cargo dead_code diagnostics with native orphan-source dead-code evidence", async () => {
     const temp = mkdtempSync(join(tmpdir(), "lattice-validation-rust-dead-code-"));
     try {
+      const logPath = join(temp, "cargo.log");
       const { env } = writeFakeRustToolchain(join(temp, "bin"), {
         cargo: {
+          logPath,
+          logEnvKeys: ["RUSTFLAGS"],
           checkStdout: `${JSON.stringify(cargoMessage("warning", "function `unused_private` is never used", "dead_code"))}\n`,
           checkStatus: 101
         }
       });
+      env.RUSTFLAGS = "explicit-flag";
       const result = await runner({
         files: rustCrate({
           "crates/app/src/lib.rs": "pub fn answer() -> i32 { 42 }\n",
@@ -1106,7 +1110,57 @@ const rustCheckIds = [
 
       assert.equal(result.status, "policy_failure", JSON.stringify(result, null, 2));
       assert.deepEqual(result.diagnostics.map((diagnostic) => diagnostic.code), ["dead_code", "RUST_DEAD_ORPHAN_SOURCE"]);
+      const cargoCheckLog = readFileSync(logPath, "utf8")
+        .split(/\r?\n/)
+        .find((line) => line.startsWith("check --message-format=json"));
+      assert.equal(
+        cargoCheckLog,
+        "check --message-format=json --all-targets --all-features\tRUSTFLAGS=explicit-flag -Ddead_code"
+      );
     } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it("runs rust.dead-code with process env PATH and appends RUSTFLAGS when no env option is supplied", async () => {
+    const temp = mkdtempSync(join(tmpdir(), "lattice-validation-rust-dead-code-env-"));
+    const originalPath = process.env.PATH;
+    const originalRustflags = process.env.RUSTFLAGS;
+    try {
+      const logPath = join(temp, "cargo.log");
+      const { bin } = writeFakeRustToolchain(join(temp, "bin"), {
+        cargo: {
+          logPath,
+          logEnvKeys: ["PATH", "RUSTFLAGS"]
+        }
+      });
+      process.env.PATH = bin;
+      process.env.RUSTFLAGS = "process-flag";
+      const files = rustCrate();
+      const content = new Map(Object.entries(files));
+      const result = await createValidationRunner({
+        workspace: {
+          readFile: (path) => (content.has(path) ? { status: "found", content: content.get(path) } : { status: "missing" }),
+          listChangedFiles: () => ({ files: [...content.keys()] }),
+          listStagedFiles: () => ({ files: [...content.keys()] }),
+          listRepoFiles: () => ({ files: [...content.keys()] }),
+          listTreeFiles: () => ({ files: [...content.keys()] }),
+          listPackageFiles: (_name, root) => ({ files: [...content.keys()].filter((path) => path.startsWith(`${root}/`)) })
+        },
+        checks: createRustValidationChecks()
+      }).runValidation(request({ checks: [RUST_DEAD_CODE_CHECK_ID] }));
+
+      assert.equal(result.status, "passed", JSON.stringify(result, null, 2));
+      const cargoCheckLog = readFileSync(logPath, "utf8")
+        .split(/\r?\n/)
+        .find((line) => line.startsWith("check --message-format=json"));
+      assert.equal(
+        cargoCheckLog,
+        `check --message-format=json --all-targets --all-features\tPATH=${bin}\tRUSTFLAGS=process-flag -Ddead_code`
+      );
+    } finally {
+      restoreProcessEnv("PATH", originalPath);
+      restoreProcessEnv("RUSTFLAGS", originalRustflags);
       rmSync(temp, { recursive: true, force: true });
     }
   });
@@ -1309,4 +1363,12 @@ function cargoMessage(level, message, code) {
       spans: [{ file_name: "crates/app/src/lib.rs", is_primary: true }]
     }
   };
+}
+
+function restoreProcessEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
 }


### PR DESCRIPTION
Closes #50

## Summary
- Preserve `process.env` for `rust.dead-code` cargo invocations when no explicit env is supplied, so `PATH` is not dropped.
- Append `-Ddead_code` to any existing `RUSTFLAGS` instead of overwriting caller or process flags.
- Add regression coverage for process-env fallback and explicit `RUSTFLAGS` append behavior.

## Validation
- `npm run build`
- `node --test tests/validation-rust.test.mjs`
- `npm run setup:tools`
- `npm run current-tools:validate-changed`

## Notes
- No public release or npm publish.
- The retained Rox changed-file gate remains the current guardrail.
- Fresh-Git `opcore check --changed` support remains delegated to #39.

Generated with zeroshot finish
