### PR TITLE
chore(zeroshot): configure cmdproof command reuse

### DIFF
--- a/.cmdproof/profiles.toml
+++ b/.cmdproof/profiles.toml
@@ -1,0 +1,43 @@
+[profile.ci-equivalent]
+argv = ["bash", "./scripts/ci/run-local-ci-equivalent.sh"]
+cwd = "."
+read_only = true
+network = "declared"
+env_allowlist = ["CI", "NODE_ENV", "PATH"]
+timeout_ms = 600000
+require.default = "trusted-agent"
+require.validator = "trusted-agent-or-ci"
+require.ci = "ci"
+
+[profile.ci-equivalent.workspace]
+include_untracked = false
+generated = [
+  "target/**",
+  "node_modules/**",
+  "**/dist/**",
+  "**/*.tsbuildinfo",
+  "coverage/**",
+  "*.tgz",
+  "*.log",
+  ".code-review-graph/**",
+  ".ace/**",
+  ".agents/**",
+  ".claude/**",
+  ".cmdproof/cache/**",
+  ".cmdproof/tmp/**",
+  ".codex/**",
+  ".gemini/**",
+  ".opencode/**",
+  ".opcore/**",
+  ".asp/**",
+  ".rox-cache/**",
+  ".robustness-engine-cache/**",
+  "packages/opcore-graph-core-*/opcore-graph-core",
+  "packages/opcore-graph-core-*/opcore-graph-core.sha256",
+  "docs/graph-reference-evidence/**",
+]
+
+[profile.ci-equivalent.output]
+stdout = "digest"
+stderr = "digest"
+artifacts = []

--- a/.zeroshot/settings.json
+++ b/.zeroshot/settings.json
@@ -7,5 +7,16 @@
     "setup": [
       "npm run setup"
     ]
+  },
+  "ship": {
+    "commandProofs": [
+      {
+        "id": "opcore-ci",
+        "profile": "ci-equivalent",
+        "scope": "repo",
+        "description": "Opcore local CI-equivalent gate",
+        "command": "bash ./scripts/ci/run-local-ci-equivalent.sh"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add the opcore `ci-equivalent` cmdproof profile for `bash ./scripts/ci/run-local-ci-equivalent.sh`
- configure Zeroshot `ship.commandProofs` with `opcore-ci` so workers and validators use `zeroshot cmdproof check opcore-ci`
- mark normal build/cache outputs as generated so proof reuse is not invalidated by dist/tsbuildinfo/caches

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('.zeroshot/settings.json','utf8'))"`
- `ZEROSHOT_CLUSTER_ID=opcore-config-test CMDPROOF_CACHE_DIR=<tmp> CMDPROOF_KEY_DIR=<tmp> zeroshot cmdproof verify opcore-ci` returned a non-executing `missing_proof` with profile/action digests
