### PR TITLE
chore(cmdproof): include untracked material inputs

### DIFF
--- a/.cmdproof/profiles.toml
+++ b/.cmdproof/profiles.toml
@@ -10,7 +10,7 @@ require.validator = "trusted-agent-or-ci"
 require.ci = "ci"
 
 [profile.ci-equivalent.workspace]
-include_untracked = false
+include_untracked = true
 generated = [
   "target/**",
   "node_modules/**",


### PR DESCRIPTION
## Summary
- include untracked material files in the cmdproof ci-equivalent workspace identity
- preserves generated/cache exclusions so build artifacts stay non-material

## Verification
- with an untracked material file present, `zeroshot cmdproof verify opcore-ci` now returns a normal `missing_proof` with an action key instead of `Untracked inputs are not allowed`
- `git diff --check`