### PR TITLE
feat(python): persist graph store facts

### DIFF
--- a/crates/graph-core/src/pipeline.rs
+++ b/crates/graph-core/src/pipeline.rs
@@ -474,6 +474,8 @@ fn attach_store_message(
             repo,
             freshness,
             db_path,
+            nodes_by_kind: None,
+            edges_by_kind: None,
             message: Some(format!(
                 "GraphProvider {operation} completed at {generated_at}"
             )),

--- a/crates/graph-core/src/protocol/provider.rs
+++ b/crates/graph-core/src/protocol/provider.rs
@@ -2,6 +2,7 @@ use super::daemon::{GraphDaemonOperation, GraphWalCheckpointSummary, GraphWatchL
 use crate::artifact::{runtime_artifact_metadata, GraphProviderArtifactMetadata};
 use crate::{GRAPH_PROVIDER_NAME, GRAPH_SCHEMA_VERSION};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -124,6 +125,10 @@ pub enum GraphProviderStatus {
         freshness: GraphFreshness,
         #[serde(skip_serializing_if = "Option::is_none")]
         db_path: Option<String>,
+        #[serde(rename = "nodes_by_kind")]
+        nodes_by_kind: BTreeMap<String, u32>,
+        #[serde(rename = "edges_by_kind")]
+        edges_by_kind: BTreeMap<String, u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         message: Option<String>,
         #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -296,6 +301,8 @@ pub fn available_status_with_freshness(
         repo,
         freshness,
         db_path,
+        nodes_by_kind: None,
+        edges_by_kind: None,
         message,
         wal_checkpoint: None,
     })
@@ -305,6 +312,8 @@ pub struct AvailableStatusInput {
     pub repo: RepoIdentity,
     pub freshness: GraphFreshness,
     pub db_path: Option<String>,
+    pub nodes_by_kind: Option<BTreeMap<String, u32>>,
+    pub edges_by_kind: Option<BTreeMap<String, u32>>,
     pub message: Option<String>,
     pub wal_checkpoint: Option<GraphWalCheckpointSummary>,
 }
@@ -317,6 +326,8 @@ pub fn available_status_with_wal_checkpoint(input: AvailableStatusInput) -> Grap
         repo: input.repo,
         freshness: input.freshness,
         db_path: input.db_path,
+        nodes_by_kind: input.nodes_by_kind.unwrap_or_default(),
+        edges_by_kind: input.edges_by_kind.unwrap_or_default(),
         message: input.message,
         capabilities: vec![
             "build".to_string(),

--- a/crates/graph-core/src/query/impact.rs
+++ b/crates/graph-core/src/query/impact.rs
@@ -3,7 +3,7 @@ use crate::store::StoreQueryOutput;
 use std::collections::{BTreeSet, VecDeque};
 
 use super::common::sorted_repo_paths;
-use super::index::{GraphIndex, Selection, SelectionAccumulator};
+use super::index::{is_test_node, GraphIndex, Selection, SelectionAccumulator};
 use super::GraphImpactOutput;
 
 pub(super) struct ImpactTraversal {
@@ -69,11 +69,7 @@ impl ImpactTraversal {
 
     fn add_contained_symbols(&self, index: &GraphIndex, selection: &mut SelectionAccumulator) {
         for file_id in selection.selected_file_ids(index) {
-            for edge in index.edges_from(&file_id, &["CONTAINS"]) {
-                if selection.add_node(index, &edge.to) {
-                    selection.add_edge_if_selected(edge);
-                }
-            }
+            selection.add_contained_descendants(index, &file_id);
         }
     }
 
@@ -108,13 +104,13 @@ impl ImpactTraversal {
         let impacted_symbols = traversal
             .nodes
             .iter()
-            .filter(|node| node.kind != "File" && node.kind != "Test")
+            .filter(|node| node.kind != "File" && !is_test_node(node))
             .map(|node| node.id.clone())
             .collect::<Vec<_>>();
         let tests = traversal
             .nodes
             .iter()
-            .filter(|node| node.kind == "Test")
+            .filter(|node| is_test_node(node))
             .filter_map(|node| index.node_file_path(&node.id))
             .collect::<BTreeSet<_>>()
             .into_iter()

--- a/crates/graph-core/src/query/index.rs
+++ b/crates/graph-core/src/query/index.rs
@@ -126,7 +126,7 @@ impl SelectionAccumulator {
                 index
                     .nodes_by_id
                     .get(*id)
-                    .is_some_and(|node| node.kind != "File" && node.kind != "Test")
+                    .is_some_and(|node| node.kind != "File" && !is_test_node(node))
             })
             .cloned()
             .collect()
@@ -196,14 +196,9 @@ impl GraphIndex {
         }
         let mut ids = vec![id.clone()];
         if id.starts_with("file:") {
-            let mut child_ids = self
-                .edges_from(&id, &["CONTAINS"])
-                .map(|edge| edge.to.clone())
-                .collect::<Vec<_>>();
-            child_ids.sort();
-            for child_id in child_ids {
-                if !ids.contains(&child_id) {
-                    ids.push(child_id);
+            for descendant_id in self.contained_descendant_ids(&id) {
+                if !ids.contains(&descendant_id) {
+                    ids.push(descendant_id);
                 }
             }
         }
@@ -276,7 +271,8 @@ impl GraphIndex {
             .cloned()
             .collect::<Vec<_>>();
         for id in selected_start_ids {
-            for edge in self.edges_from(&id, &["CONTAINS", "IMPORTS_FROM", "DEPENDS_ON"]) {
+            selection.add_contained_descendants(self, &id);
+            for edge in self.edges_from(&id, &["IMPORTS_FROM", "DEPENDS_ON"]) {
                 if selection.add_node(self, &edge.to) {
                     selection.add_edge_if_selected(edge);
                 }
@@ -288,6 +284,23 @@ impl GraphIndex {
             }
         }
         selection.into_selection(self, 1)
+    }
+
+    pub(super) fn contained_descendant_ids(&self, root_id: &str) -> Vec<String> {
+        let mut descendants = BTreeSet::new();
+        let mut visited = BTreeSet::new();
+        let mut queue = VecDeque::from([root_id.to_string()]);
+        while let Some(current) = queue.pop_front() {
+            if !visited.insert(current.clone()) {
+                continue;
+            }
+            for edge in self.edges_from(&current, &["CONTAINS"]) {
+                if descendants.insert(edge.to.clone()) {
+                    queue.push_back(edge.to.clone());
+                }
+            }
+        }
+        descendants.into_iter().collect()
     }
 
     pub(super) fn nodes_for_ids(&self, ids: &BTreeSet<String>) -> Vec<GraphFactNode> {
@@ -345,6 +358,19 @@ impl GraphIndex {
     }
 }
 
+impl SelectionAccumulator {
+    pub(super) fn add_contained_descendants(&mut self, index: &GraphIndex, root_id: &str) {
+        for descendant_id in index.contained_descendant_ids(root_id) {
+            self.add_node(index, &descendant_id);
+        }
+        for edge in &index.edges {
+            if edge.kind == "CONTAINS" {
+                self.add_edge_if_selected(edge);
+            }
+        }
+    }
+}
+
 fn traversal_queue(
     start_ids: &[String],
     selection: &SelectionAccumulator,
@@ -362,4 +388,14 @@ fn next_traversal_node(edge: &GraphFactEdge, direction: Direction) -> String {
         Direction::Incoming => edge.from.clone(),
         Direction::Outgoing => edge.to.clone(),
     }
+}
+
+pub(super) fn is_test_node(node: &GraphFactNode) -> bool {
+    node.kind == "Test"
+        || node
+            .attributes
+            .as_ref()
+            .and_then(|attributes| attributes.get("isTest"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
 }

--- a/crates/graph-core/src/query/tests.rs
+++ b/crates/graph-core/src/query/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::protocol::{GraphFactQueryKind, GraphFreshness, GraphProviderMode, RepoIdentity};
+use serde_json::json;
 use std::collections::BTreeSet;
 
 #[test]
@@ -27,6 +28,85 @@ fn impact_traverses_reverse_file_dependencies_and_tests() {
         .tests
         .contains(&"src/__tests__/greeting.test.ts".to_string()));
     assert!(!output.traversal.truncated);
+}
+
+#[test]
+fn python_file_queries_traverse_nested_symbols_and_is_test_functions() {
+    let snapshot = python_test_snapshot();
+    let tests = named_query(
+        &snapshot,
+        &GraphNamedQueryRequest {
+            request_id: None,
+            repo: repo(),
+            schema_version: 1,
+            mode: GraphProviderMode::Required,
+            query_kind: GraphNamedQueryKind::TestsFor,
+            target: "src/pkg/models.py".to_string(),
+            max_depth: Some(1),
+            limit: Some(100),
+        },
+    );
+    assert!(tests
+        .nodes
+        .iter()
+        .any(|node| node.path.as_deref() == Some("tests/test_models.py")));
+
+    let summary = named_query(
+        &snapshot,
+        &GraphNamedQueryRequest {
+            request_id: None,
+            repo: repo(),
+            schema_version: 1,
+            mode: GraphProviderMode::Required,
+            query_kind: GraphNamedQueryKind::FileSummary,
+            target: "src/pkg/models.py".to_string(),
+            max_depth: None,
+            limit: Some(100),
+        },
+    );
+    assert!(summary
+        .edges
+        .iter()
+        .any(|edge| edge.kind == "CONTAINS" && edge.to == "class:src/pkg/models.py#PublicModel"));
+
+    let impact = impact(
+        &snapshot,
+        &GraphImpactRequest {
+            request_id: None,
+            repo: repo(),
+            schema_version: 1,
+            mode: GraphProviderMode::Required,
+            files: vec!["src/pkg/models.py".to_string()],
+            base_ref: None,
+            max_depth: Some(3),
+            limit: Some(100),
+        },
+    );
+    assert!(impact.tests.contains(&"tests/test_models.py".to_string()));
+    assert!(impact
+        .impacted_symbols
+        .contains(&"class:src/pkg/models.py#PublicModel".to_string()));
+    assert!(!impact
+        .impacted_symbols
+        .contains(&"function:tests/test_models.py#test_make_model".to_string()));
+
+    let review = review_context(
+        &snapshot,
+        &[hash("src/pkg/models.py", "aaa")],
+        &[hash("src/pkg/models.py", "bbb")],
+        &GraphReviewContextRequest {
+            request_id: None,
+            repo: repo(),
+            schema_version: 1,
+            mode: GraphProviderMode::Required,
+            files: vec!["src/pkg/models.py".to_string()],
+            base_ref: None,
+            max_depth: Some(3),
+            limit: Some(100),
+        },
+    );
+    assert_eq!(review.changed_files, vec!["src/pkg/models.py"]);
+    assert!(review.tests.contains(&"tests/test_models.py".to_string()));
 }
 
 #[test]
@@ -418,6 +498,124 @@ fn cycle_snapshot() -> StoreQueryOutput {
     }
 }
 
+fn python_test_snapshot() -> StoreQueryOutput {
+    StoreQueryOutput {
+        metadata: python_test_metadata(),
+        nodes: python_test_nodes(),
+        edges: python_test_edges(),
+        diagnostics: Vec::new(),
+    }
+}
+
+fn python_test_metadata() -> GraphSnapshotMetadata {
+    GraphSnapshotMetadata {
+        schema_version: 1,
+        provider: "lattice-graph".to_string(),
+        repo: repo(),
+        generated_at: "2026-06-04T00:00:00.000Z".to_string(),
+        freshness: GraphFreshness {
+            generated_at: "2026-06-04T00:00:00.000Z".to_string(),
+            age_ms: 0,
+            max_age_ms: None,
+            stale: false,
+            reason: None,
+        },
+        node_kinds: vec![
+            "File".to_string(),
+            "Module".to_string(),
+            "Class".to_string(),
+            "Function".to_string(),
+        ],
+        edge_kinds: vec![
+            "CONTAINS".to_string(),
+            "IMPORTS_FROM".to_string(),
+            "TESTED_BY".to_string(),
+        ],
+    }
+}
+
+fn python_test_nodes() -> Vec<GraphFactNode> {
+    vec![
+        node("file:src/pkg/models.py", "File", Some("src/pkg/models.py")),
+        node(
+            "module:src/pkg/models.py#src.pkg.models",
+            "Module",
+            Some("src/pkg/models.py"),
+        ),
+        node(
+            "class:src/pkg/models.py#PublicModel",
+            "Class",
+            Some("src/pkg/models.py"),
+        ),
+        node(
+            "function:src/pkg/models.py#make_model",
+            "Function",
+            Some("src/pkg/models.py"),
+        ),
+        node(
+            "file:tests/test_models.py",
+            "File",
+            Some("tests/test_models.py"),
+        ),
+        node(
+            "module:tests/test_models.py#tests.test_models",
+            "Module",
+            Some("tests/test_models.py"),
+        ),
+        node_with_attributes(
+            "function:tests/test_models.py#test_make_model",
+            "Function",
+            Some("tests/test_models.py"),
+            json!({"isTest": true}),
+        ),
+    ]
+}
+
+fn python_test_edges() -> Vec<GraphFactEdge> {
+    vec![
+        edge(
+            "CONTAINS",
+            "file:src/pkg/models.py",
+            "module:src/pkg/models.py#src.pkg.models",
+        ),
+        edge(
+            "CONTAINS",
+            "module:src/pkg/models.py#src.pkg.models",
+            "class:src/pkg/models.py#PublicModel",
+        ),
+        edge(
+            "CONTAINS",
+            "module:src/pkg/models.py#src.pkg.models",
+            "function:src/pkg/models.py#make_model",
+        ),
+        edge(
+            "CONTAINS",
+            "file:tests/test_models.py",
+            "module:tests/test_models.py#tests.test_models",
+        ),
+        edge(
+            "CONTAINS",
+            "module:tests/test_models.py#tests.test_models",
+            "function:tests/test_models.py#test_make_model",
+        ),
+        edge(
+            "IMPORTS_FROM",
+            "file:tests/test_models.py",
+            "file:src/pkg/models.py",
+        ),
+        edge(
+            "TESTED_BY",
+            "class:src/pkg/models.py#PublicModel",
+            "function:tests/test_models.py#test_make_model",
+        ),
+        edge(
+            "TESTED_BY",
+            "function:src/pkg/models.py#make_model",
+            "function:tests/test_models.py#test_make_model",
+        ),
+    ]
+}
+
 fn repo() -> RepoIdentity {
     RepoIdentity {
         repo_id: Some("fixture".to_string()),
@@ -434,6 +632,18 @@ fn node(id: &str, kind: &str, path: Option<&str>) -> GraphFactNode {
         path: path.map(str::to_string),
         name: None,
         attributes: None,
+    }
+}
+
+fn node_with_attributes(
+    id: &str,
+    kind: &str,
+    path: Option<&str>,
+    attributes: serde_json::Value,
+) -> GraphFactNode {
+    GraphFactNode {
+        attributes: Some(attributes),
+        ..node(id, kind, path)
     }
 }
 

--- a/crates/graph-core/src/store.rs
+++ b/crates/graph-core/src/store.rs
@@ -10,6 +10,7 @@ use crate::protocol::{
 use crate::query::{select_graph_facts, GraphStoreQueryResult};
 use crate::search;
 use rusqlite::{params, Connection, OpenFlags, TransactionBehavior};
+use std::collections::BTreeMap;
 use std::path::Path;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
@@ -233,6 +234,8 @@ impl GraphStore {
                     repo: metadata.repo,
                     freshness,
                     db_path: Some(display_path(&self.paths.db_path)),
+                    nodes_by_kind: Some(self.read_kind_counts("nodes")?),
+                    edges_by_kind: Some(self.read_kind_counts("edges")?),
                     message: Some("graph store snapshot available".to_string()),
                     wal_checkpoint,
                 }))
@@ -421,6 +424,21 @@ impl GraphStore {
         )?;
         let rows = statement.query_map([], read_edge_row)?;
         collect_rows(rows)
+    }
+
+    fn read_kind_counts(&self, table: &str) -> StoreResult<BTreeMap<String, u32>> {
+        let sql = match table {
+            "nodes" => "select kind, count(*) from nodes group by kind order by kind",
+            "edges" => "select kind, count(*) from edges group by kind order by kind",
+            _ => {
+                return Err(StoreError::InvalidSnapshot(format!(
+                    "unsupported graph store count table: {table}"
+                )))
+            }
+        };
+        let mut statement = self.connection.prepare(sql)?;
+        let rows = statement.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        Ok(collect_rows(rows)?.into_iter().collect())
     }
 }
 

--- a/crates/graph-core/src/store/write.rs
+++ b/crates/graph-core/src/store/write.rs
@@ -327,7 +327,7 @@ fn node_insert_row(
         qualified_name: node.id.clone(),
         file_path: node_file_path(context, path.as_deref(), file_hash),
         language: file_hash.map(|hash| hash.language.clone()),
-        is_test: if node.kind == "Test" { 1 } else { 0 },
+        is_test: if is_test_node(node) { 1 } else { 0 },
         is_exported: if node
             .attributes
             .as_ref()
@@ -345,6 +345,16 @@ fn node_insert_row(
         attributes_json: optional_json(&node.attributes)?,
         canonical_json: serde_json::to_string(node)?,
     })
+}
+
+fn is_test_node(node: &GraphFactNode) -> bool {
+    node.kind == "Test"
+        || node
+            .attributes
+            .as_ref()
+            .and_then(|attributes| attributes.get("isTest"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
 }
 
 fn node_file_path(

--- a/crates/graph-core/src/watch.rs
+++ b/crates/graph-core/src/watch.rs
@@ -156,6 +156,8 @@ fn watch_response_from_pipeline(
         db_path: Some(display_path(
             &repo_root.join(".lattice").join("graph").join("graph.db"),
         )),
+        nodes_by_kind: None,
+        edges_by_kind: None,
         message: Some("graph watch daemon available".to_string()),
         wal_checkpoint: pipeline.summary.wal_checkpoint.clone(),
     });

--- a/packages/contracts/schemas/lattice-contracts.schema.json
+++ b/packages/contracts/schemas/lattice-contracts.schema.json
@@ -442,7 +442,9 @@
             "provider",
             "schemaVersion",
             "repo",
-            "freshness"
+            "freshness",
+            "nodes_by_kind",
+            "edges_by_kind"
           ],
           "properties": {
             "state": {
@@ -469,6 +471,20 @@
             },
             "dbPath": {
               "type": "string"
+            },
+            "nodes_by_kind": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "edges_by_kind": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              }
             },
             "message": {
               "type": "string"

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -245,6 +245,8 @@ export interface GraphProviderAvailableStatus extends GraphProviderStatusBase {
   repo: RepoIdentity;
   freshness: GraphFreshness;
   dbPath?: string;
+  nodes_by_kind: Readonly<Record<string, number>>;
+  edges_by_kind: Readonly<Record<string, number>>;
   capabilities?: readonly string[];
   handshake?: GraphProviderCapabilityHandshake;
   walCheckpoint?: GraphWalCheckpointSummary;
@@ -4768,6 +4770,8 @@ export function validateProviderStatus(status: GraphProviderStatus): GraphProvid
   if (status.state === "available") {
     validateRepoIdentity(status.repo);
     validateGraphFreshness(status.freshness, "Available");
+    validateGraphKindCounts(status.nodes_by_kind, "nodes_by_kind");
+    validateGraphKindCounts(status.edges_by_kind, "edges_by_kind");
     if (status.handshake !== undefined) validateGraphProviderCapabilityHandshake(status.handshake);
     if (status.walCheckpoint !== undefined) validateGraphWalCheckpointSummary(status.walCheckpoint);
     return status;
@@ -4780,6 +4784,18 @@ export function validateProviderStatus(status: GraphProviderStatus): GraphProvid
   }
   validateProviderFailureStatus(status);
   return status;
+}
+
+function validateGraphKindCounts(counts: Readonly<Record<string, number>>, label: string): void {
+  if (!counts || typeof counts !== "object" || Array.isArray(counts)) {
+    throw new Error(`Graph provider status ${label} must be an object`);
+  }
+  for (const [kind, count] of Object.entries(counts)) {
+    if (kind.length === 0) throw new Error(`Graph provider status ${label} kind must not be empty`);
+    if (!Number.isInteger(count) || count < 0) {
+      throw new Error(`Graph provider status ${label}.${kind} must be a non-negative integer`);
+    }
+  }
 }
 
 function validateProviderFailureStatus(status: GraphProviderFailureStatus): void {

--- a/packages/graph/src/sidecar.ts
+++ b/packages/graph/src/sidecar.ts
@@ -230,6 +230,8 @@ function lifecycleStatus(request: GraphDaemonRequest, lifecycle: GraphWatchLifec
       repo: request.repo,
       freshness,
       dbPath: request.repo.repoRoot ? join(resolve(request.repo.repoRoot), ".lattice", "graph", "graph.db") : undefined,
+      nodes_by_kind: {},
+      edges_by_kind: {},
       message: lifecycle.message ?? "graph watch daemon available",
       capabilities: ["build", "update", "watch", "status", "query", "impact", "review-context", "detect-changes", "search"]
     };

--- a/scripts/ci/run-local-ci-equivalent.sh
+++ b/scripts/ci/run-local-ci-equivalent.sh
@@ -4,9 +4,41 @@ set -euo pipefail
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo_root}"
 
+generated_artifact_backup=""
+
 run_step() {
   printf '\n==> %s\n' "$*"
   "$@"
+}
+
+snapshot_generated_artifacts() {
+  generated_artifact_backup="$(mktemp -d "${TMPDIR:-/tmp}/opcore-generated-artifacts.XXXXXX")"
+  while IFS= read -r path; do
+    [ -n "${path}" ] || continue
+    mkdir -p "${generated_artifact_backup}/$(dirname "${path}")"
+    cp -p "${path}" "${generated_artifact_backup}/${path}"
+  done < <(
+    git ls-files \
+      'packages/opcore-graph-core-*/lattice-graph-core' \
+      'packages/opcore-graph-core-*/lattice-graph-core.sha256' \
+      'packages/opcore-graph-core-*/metadata.json'
+  )
+}
+
+restore_generated_artifacts() {
+  [ -n "${generated_artifact_backup}" ] || return 0
+  [ -d "${generated_artifact_backup}" ] || return 0
+  while IFS= read -r path; do
+    [ -n "${path}" ] || continue
+    cp -p "${generated_artifact_backup}/${path}" "${path}"
+  done < <(
+    git ls-files \
+      'packages/opcore-graph-core-*/lattice-graph-core' \
+      'packages/opcore-graph-core-*/lattice-graph-core.sha256' \
+      'packages/opcore-graph-core-*/metadata.json'
+  )
+  rm -rf "${generated_artifact_backup}"
+  generated_artifact_backup=""
 }
 
 collect_changed_files() {
@@ -58,7 +90,7 @@ run_docs_or_agent_gate() {
 }
 
 changed_file_list="$(mktemp "${TMPDIR:-/tmp}/opcore-local-ci-changed.XXXXXX")"
-trap 'rm -f "${changed_file_list}"' EXIT
+trap 'restore_generated_artifacts; rm -f "${changed_file_list}"' EXIT
 collect_changed_files > "${changed_file_list}"
 
 if docs_or_agent_only_changes "${changed_file_list}"; then
@@ -67,6 +99,8 @@ if docs_or_agent_only_changes "${changed_file_list}"; then
 fi
 
 run_step npm run setup:tools
+snapshot_generated_artifacts
 run_step npm run ci
+restore_generated_artifacts
 run_step npm run current-tools:validate-all
 run_step npm run current-tools:validate-rust-graph

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -275,6 +275,8 @@ describe("lattice shared contracts", () => {
         ageMs: 0,
         stale: false
       },
+      nodes_by_kind: {},
+      edges_by_kind: {},
       walCheckpoint: validWalCheckpoint(),
       handshake: validHandshake()
     });
@@ -344,6 +346,8 @@ describe("lattice shared contracts", () => {
           ageMs: 0,
           stale: false
         },
+        nodes_by_kind: {},
+        edges_by_kind: {},
         handshake
       }
     });
@@ -3432,7 +3436,9 @@ function availableGraphStatus() {
       generatedAt: "2026-06-05T00:00:00.000Z",
       ageMs: 0,
       stale: false
-    }
+    },
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 
@@ -3519,7 +3525,9 @@ function validGraphSearchResult() {
         generatedAt: "2026-06-04T00:00:00.000Z",
         ageMs: 0,
         stale: false
-      }
+      },
+      nodes_by_kind: {},
+      edges_by_kind: {}
     },
     metadata: {
       schemaVersion: 1,

--- a/tests/edit-symbols.test.mjs
+++ b/tests/edit-symbols.test.mjs
@@ -766,7 +766,9 @@ function availableStatus(repo, freshnessId) {
       generatedAt: `2026-06-05T00:00:00.000Z-${freshnessId}`,
       ageMs: 0,
       stale: false
-    }
+    },
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 
@@ -796,7 +798,9 @@ function passedValidation() {
       provider: "lattice-graph",
       schemaVersion: 1,
       repo: { repoId: "validation" },
-      freshness: { generatedAt: "2026-06-05T00:00:00.000Z", ageMs: 0, stale: false }
+      freshness: { generatedAt: "2026-06-05T00:00:00.000Z", ageMs: 0, stale: false },
+      nodes_by_kind: {},
+      edges_by_kind: {}
     }
   };
 }

--- a/tests/edit-validation.test.mjs
+++ b/tests/edit-validation.test.mjs
@@ -368,7 +368,9 @@ function availableStatus(repo) {
       generatedAt: "2026-06-05T00:00:00.000Z",
       ageMs: 0,
       stale: false
-    }
+    },
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 

--- a/tests/graph-store-conformance.test.mjs
+++ b/tests/graph-store-conformance.test.mjs
@@ -7,16 +7,24 @@ import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   graphProviderBuild,
+  graphProviderDetectChanges,
+  graphProviderImpact,
+  graphProviderNamedQuery,
   graphProviderQuery,
+  graphProviderReviewContext,
+  graphProviderSearch,
   graphProviderStatus,
   graphProviderUpdate,
-  graphProviderWatch
+  graphProviderWatch,
+  invokeGraphCoreSidecar
 } from "../packages/graph/dist/index.js";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const sourceFixtureRoot = resolve(repoRoot, "packages/fixtures/source-extraction/wave1");
+const pythonFixtureRoot = resolve(repoRoot, "packages/fixtures/source-extraction/python");
 const robustnessFixtureRoot = resolve(repoRoot, "packages/fixtures/graph-robustness/watch-roots");
 const expected = JSON.parse(readFileSync(resolve(sourceFixtureRoot, "wave1.expected.json"), "utf8"));
+const pythonExpected = JSON.parse(readFileSync(resolve(pythonFixtureRoot, "python.expected.json"), "utf8"));
 
 describe("GraphProvider SQLite store conformance", () => {
   it("refreshes Wave 1 facts into SQLite and serves #19 direct-reader queries", () => {
@@ -93,6 +101,237 @@ describe("GraphProvider SQLite store conformance", () => {
             { key: "schema_version", value: "6" }
           ]
         );
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it("persists Python facts into SQLite and serves store-backed query/search", () => {
+    withPythonFixtureCopy((fixtureRoot) => {
+      const canonicalFixtureRoot = realpathSync(fixtureRoot);
+      const refresh = graphProviderBuild({ repoRoot: fixtureRoot }).status;
+      assert.equal(refresh.state, "available");
+      assert.ok(refresh.dbPath);
+      assert.equal(refresh.dbPath, join(canonicalFixtureRoot, ".lattice/graph/graph.db"));
+      assert.ok(existsSync(refresh.dbPath));
+
+      const status = graphProviderStatus({ repoRoot: fixtureRoot });
+      assert.equal(status.state, "available");
+      assert.equal(status.dbPath, refresh.dbPath);
+      assert.deepEqual(status.nodes_by_kind, {
+        Class: 3,
+        File: 7,
+        Function: 9,
+        Module: 7,
+        Variable: 2
+      });
+      assert.deepEqual(status.edges_by_kind, {
+        CALLS: 9,
+        CONTAINS: 21,
+        DEPENDS_ON: 6,
+        IMPORTS_FROM: 6,
+        INHERITS: 1,
+        TESTED_BY: 3
+      });
+      const rawStatus = rawGraphStatus(fixtureRoot);
+      assert.equal(rawStatus.state, "available");
+      assert.deepEqual(rawStatus.nodes_by_kind, status.nodes_by_kind);
+      assert.deepEqual(rawStatus.edges_by_kind, status.edges_by_kind);
+
+      const result = graphProviderQuery({ repoRoot: fixtureRoot });
+      assert.equal(result.status.state, "available");
+      assert.equal(result.status.dbPath, refresh.dbPath);
+      assert.deepEqual(result.nodes.map((node) => node.id).sort(), pythonExpected.nodeIds);
+      assert.deepEqual(edgeTriples(result.edges), pythonExpected.edgeTriples.sort(compareTuple));
+
+      const db = new DatabaseSync(refresh.dbPath, { readOnly: true });
+      try {
+        assert.equal(db.prepare("pragma user_version").get().user_version, 1);
+        assert.deepEqual(
+          plainRows(db.prepare("select kind, count(*) as count from nodes group by kind order by kind").all()),
+          [
+            { kind: "Class", count: 3 },
+            { kind: "File", count: 7 },
+            { kind: "Function", count: 9 },
+            { kind: "Module", count: 7 },
+            { kind: "Variable", count: 2 }
+          ]
+        );
+        assert.deepEqual(
+          plainRows(db.prepare("select kind, count(*) as count from edges group by kind order by kind").all()),
+          [
+            { kind: "CALLS", count: 9 },
+            { kind: "CONTAINS", count: 21 },
+            { kind: "DEPENDS_ON", count: 6 },
+            { kind: "IMPORTS_FROM", count: 6 },
+            { kind: "INHERITS", count: 1 },
+            { kind: "TESTED_BY", count: 3 }
+          ]
+        );
+        assert.deepEqual(
+          plainRows(db.prepare("select language, count(*) as count from file_hashes group by language").all()),
+          [{ language: "python", count: 7 }]
+        );
+        assert.deepEqual(
+          Object.fromEntries(
+            db
+              .prepare(
+                "select name, is_exported from nodes where name in ('PublicModel', 'make_model', 'build_name', '_hidden') order by name"
+              )
+              .all()
+              .map((row) => [row.name, row.is_exported])
+          ),
+          { PublicModel: 1, _hidden: 0, build_name: 1, make_model: 1 }
+        );
+        assert.equal(
+          db.prepare("select is_test from nodes where id = ?").get("function:tests/test_models.py#test_make_model").is_test,
+          1
+        );
+        for (const nodeId of [
+          "class:src/pkg/models.py#PublicModel",
+          "function:src/pkg/helpers.py#build_name",
+          "function:src/pkg/stubs.pyi#stubbed"
+        ]) {
+          assert.equal(db.prepare("select count(*) as count from nodes_fts where node_id = ?").get(nodeId).count, 1, nodeId);
+        }
+        assert.ok(db.prepare("select count(*) as count from nodes_fts where path = ?").get("src/pkg/stubs.pyi").count > 0);
+      } finally {
+        db.close();
+      }
+
+      const symbols = graphProviderQuery(
+        { repoRoot: fixtureRoot },
+        { kind: "symbols", text: "PublicModel", limit: 100 }
+      );
+      assert.equal(symbols.status.state, "available");
+      assert.ok(symbols.nodes.map((node) => node.id).includes("class:src/pkg/models.py#PublicModel"));
+
+      const imports = graphProviderQuery(
+        { repoRoot: fixtureRoot },
+        { kind: "edges", edgeKinds: ["IMPORTS_FROM"], ids: ["file:tests/test_models.py"], limit: 100 }
+      );
+      assert.equal(imports.status.state, "available");
+      assert.deepEqual(
+        imports.edges.map((edge) => edge.to).sort(),
+        ["file:src/pkg/__init__.py", "file:src/pkg/models.py"]
+      );
+
+      const testedBy = graphProviderQuery(
+        { repoRoot: fixtureRoot },
+        { kind: "neighbors", edgeKinds: ["TESTED_BY"], ids: ["class:src/pkg/models.py#PublicModel"], limit: 100 }
+      );
+      assert.equal(testedBy.status.state, "available");
+      assert.ok(paths(testedBy.nodes).includes("tests/test_models.py"));
+
+      const search = graphProviderSearch({ repoRoot: fixtureRoot }, { query: "PublicModel", limit: 5 });
+      assert.equal(search.status.state, "available");
+      assert.equal(search.results[0].rank, 1);
+      assert.equal(search.results[0].nodeId, "class:src/pkg/models.py#PublicModel");
+
+      const importers = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "importers_of", target: "src/pkg/models.py", maxDepth: 2, limit: 100 }
+      );
+      assert.equal(importers.status.state, "available");
+      assert.deepEqual(paths(importers.nodes), ["src/pkg/__init__.py", "src/pkg/models.py", "tests/test_models.py"]);
+
+      const tests = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "tests_for", target: "src/pkg/models.py", maxDepth: 1, limit: 100 }
+      );
+      assert.equal(tests.status.state, "available");
+      assert.ok(paths(tests.nodes).includes("tests/test_models.py"));
+      const rawTests = rawNamedQuery(fixtureRoot, {
+        queryKind: "tests_for",
+        target: "src/pkg/models.py",
+        maxDepth: 1,
+        limit: 100
+      });
+      assert.equal(rawTests.status.state, "available");
+      assert.deepEqual(paths(rawTests.nodes), paths(tests.nodes));
+
+      const children = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "children_of", target: "src/pkg/models.py", maxDepth: 2, limit: 100 }
+      );
+      assert.equal(children.status.state, "available");
+      assert.ok(children.nodes.map((node) => node.id).includes("class:src/pkg/models.py#PublicModel"));
+      assert.ok(children.nodes.map((node) => node.id).includes("function:src/pkg/models.py#make_model"));
+
+      const summary = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "file_summary", target: "src/pkg/models.py", limit: 100 }
+      );
+      assert.equal(summary.status.state, "available");
+      assert.ok(summary.edges.some((edge) => edge.kind === "CONTAINS" && edge.to === "class:src/pkg/models.py#PublicModel"));
+      const rawSummary = rawNamedQuery(fixtureRoot, { queryKind: "file_summary", target: "src/pkg/models.py", limit: 100 });
+      assert.equal(rawSummary.status.state, "available");
+      assert.ok(rawSummary.edges.some((edge) => edge.kind === "CONTAINS" && edge.to === "class:src/pkg/models.py#PublicModel"));
+
+      const impact = graphProviderImpact({ repoRoot: fixtureRoot }, { files: ["src/pkg/models.py"], maxDepth: 3, limit: 100 });
+      assert.equal(impact.status.state, "available");
+      assert.deepEqual(impact.changedFiles, ["src/pkg/models.py"]);
+      assert.ok(impact.impactedFiles.includes("tests/test_models.py"));
+      assert.ok(impact.tests.includes("tests/test_models.py"));
+      const rawImpact = rawGraphImpact(fixtureRoot, { files: ["src/pkg/models.py"], maxDepth: 3, limit: 100 });
+      assert.equal(rawImpact.status.state, "available");
+      assert.ok(rawImpact.impactedFiles.includes("tests/test_models.py"));
+      assert.ok(rawImpact.tests.includes("tests/test_models.py"));
+
+      const changes = graphProviderDetectChanges({ repoRoot: fixtureRoot }, { files: ["src/pkg/models.py"] });
+      assert.equal(changes.status.state, "available");
+      assert.deepEqual(changes.changedFiles, ["src/pkg/models.py"]);
+
+      const review = graphProviderReviewContext({ repoRoot: fixtureRoot }, { files: ["src/pkg/models.py"], maxDepth: 3 });
+      assert.equal(review.status.state, "available");
+      assert.deepEqual(review.changedFiles, ["src/pkg/models.py"]);
+      assert.ok(review.impactedFiles.includes("tests/test_models.py"));
+      assert.ok(review.tests.includes("tests/test_models.py"));
+      const rawReview = rawGraphReviewContext(fixtureRoot, { files: ["src/pkg/models.py"], maxDepth: 3 });
+      assert.equal(rawReview.status.state, "available");
+      assert.ok(rawReview.impactedFiles.includes("tests/test_models.py"));
+      assert.ok(rawReview.tests.includes("tests/test_models.py"));
+    });
+  });
+
+  it("updates Python changed and deleted files incrementally", () => {
+    withPythonFixtureCopy((fixtureRoot) => {
+      const build = graphProviderBuild({ repoRoot: fixtureRoot });
+      assert.equal(build.status.state, "available");
+
+      writeFileSync(
+        join(fixtureRoot, "src/pkg/helpers.py"),
+        `${readFileSync(join(fixtureRoot, "src/pkg/helpers.py"), "utf8")}\n\ndef helper_added():\n    return build_name()\n`
+      );
+      unlinkSync(join(fixtureRoot, "src/pkg/stubs.pyi"));
+
+      const stale = graphProviderStatus({ repoRoot: fixtureRoot });
+      assert.equal(stale.state, "stale");
+      assert.match(stale.freshness.reason, /hash changed|removed/);
+
+      const update = graphProviderUpdate({ repoRoot: fixtureRoot }, "HEAD");
+      assert.equal(update.status.state, "available");
+      assert.deepEqual(update.summary.changedFiles, ["src/pkg/helpers.py"]);
+      assert.deepEqual(update.summary.deletedFiles, ["src/pkg/stubs.pyi"]);
+      assert.equal(update.summary.fullRebuildRequired, false);
+      assert.equal(update.summary.parsedFiles, 1);
+
+      assertStoreMissingPath(update.status.dbPath, "src/pkg/stubs.pyi");
+      const db = new DatabaseSync(update.status.dbPath, { readOnly: true });
+      try {
+        assert.equal(
+          db.prepare("select count(*) as count from nodes_fts where node_id = ?").get("function:src/pkg/helpers.py#helper_added")
+            .count,
+          1
+        );
+        const cached = JSON.parse(db.prepare("select value from lattice_store where key = 'file_facts_json'").get().value);
+        assert.equal(cached.some((facts) => facts.path === "src/pkg/stubs.pyi"), false);
+        const metadata = JSON.parse(db.prepare("select value from lattice_store where key = 'search_index_last_update_json'").get().value);
+        assert.equal(metadata.strategy, "incremental");
+        assert.deepEqual(metadata.changedFiles, ["src/pkg/helpers.py"]);
+        assert.deepEqual(metadata.deletedFiles, ["src/pkg/stubs.pyi"]);
+        assert.ok(metadata.reindexedNodeIds.includes("function:src/pkg/helpers.py#helper_added"));
       } finally {
         db.close();
       }
@@ -363,6 +602,17 @@ function withFixtureCopy(run) {
   }
 }
 
+function withPythonFixtureCopy(run) {
+  const temp = mkdtempSync(join(tmpdir(), "lattice-store-python-"));
+  const fixtureRoot = join(temp, "python");
+  try {
+    cpSync(pythonFixtureRoot, fixtureRoot, { recursive: true, filter: skipGeneratedStore });
+    run(fixtureRoot, temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
 function withRobustnessFixtureCopy(run) {
   const temp = mkdtempSync(join(tmpdir(), "lattice-store-robustness-"));
   const fixtureRoot = join(temp, "watch-roots");
@@ -399,6 +649,70 @@ function skipGeneratedStore(source) {
 
 function edgeTriples(edges) {
   return edges.map((edge) => [edge.kind, edge.from, edge.to]).sort(compareTuple);
+}
+
+function paths(nodes) {
+  return [...new Set(nodes.map((node) => node.path).filter(Boolean))].sort();
+}
+
+function rawGraphStatus(repoRoot) {
+  return invokeGraphCoreSidecar(baseRawGraphRequest(repoRoot, "raw-status", "status")).status;
+}
+
+function rawNamedQuery(repoRoot, options) {
+  return invokeGraphCoreSidecar({
+    ...baseRawGraphRequest(repoRoot, "raw-named-query", "query"),
+    namedQuery: {
+      requestId: "raw-named-query",
+      repo: { repoRoot },
+      schemaVersion: 1,
+      mode: "required",
+      queryKind: options.queryKind,
+      target: options.target,
+      maxDepth: options.maxDepth,
+      limit: options.limit
+    }
+  }).namedQuery;
+}
+
+function rawGraphImpact(repoRoot, options) {
+  return invokeGraphCoreSidecar({
+    ...baseRawGraphRequest(repoRoot, "raw-impact", "query"),
+    impact: {
+      requestId: "raw-impact",
+      repo: { repoRoot },
+      schemaVersion: 1,
+      mode: "required",
+      files: options.files,
+      maxDepth: options.maxDepth,
+      limit: options.limit
+    }
+  }).impact;
+}
+
+function rawGraphReviewContext(repoRoot, options) {
+  return invokeGraphCoreSidecar({
+    ...baseRawGraphRequest(repoRoot, "raw-review-context", "query"),
+    reviewContext: {
+      requestId: "raw-review-context",
+      repo: { repoRoot },
+      schemaVersion: 1,
+      mode: "required",
+      files: options.files,
+      maxDepth: options.maxDepth,
+      limit: options.limit
+    }
+  }).reviewContext;
+}
+
+function baseRawGraphRequest(repoRoot, requestId, operation) {
+  return {
+    protocol: "lattice.graph.daemon",
+    requestId,
+    schemaVersion: 1,
+    operation,
+    repo: { repoRoot }
+  };
 }
 
 function compareTuple(left, right) {

--- a/tests/opcore-metrics.test.mjs
+++ b/tests/opcore-metrics.test.mjs
@@ -283,7 +283,9 @@ function repoState(overrides = {}) {
           generatedAt: "2026-06-25T00:00:00.000Z",
           ageMs: 0,
           stale: false
-        }
+        },
+        nodes_by_kind: {},
+        edges_by_kind: {}
       }
     },
     validation: {

--- a/tests/schema-contracts.test.mjs
+++ b/tests/schema-contracts.test.mjs
@@ -247,6 +247,8 @@ const availableStatus = {
     ageMs: 0,
     stale: false
   },
+  nodes_by_kind: {},
+  edges_by_kind: {},
   handshake: validHandshake()
 };
 

--- a/tests/validation-command-adapter.test.mjs
+++ b/tests/validation-command-adapter.test.mjs
@@ -546,7 +546,9 @@ function availableGraphStatus(repoRoot) {
       generatedAt: "2026-06-05T00:00:00.000Z",
       ageMs: 0,
       stale: false
-    }
+    },
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 

--- a/tests/validation-graph-client.test.mjs
+++ b/tests/validation-graph-client.test.mjs
@@ -499,7 +499,9 @@ function availableStatus(mode = "optional", repo = { repoId: "lattice" }) {
     provider: "lattice-graph",
     schemaVersion: 1,
     repo,
-    freshness: freshness()
+    freshness: freshness(),
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 

--- a/tests/validation-runner.test.mjs
+++ b/tests/validation-runner.test.mjs
@@ -570,7 +570,9 @@ function availableStatus(mode = "optional", repo = { repoId: "lattice" }) {
       generatedAt: "2026-06-05T00:00:00.000Z",
       ageMs: 10,
       stale: false
-    }
+    },
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 

--- a/tests/validation-typescript.test.mjs
+++ b/tests/validation-typescript.test.mjs
@@ -1182,7 +1182,9 @@ function availableStatus(mode = "optional", repo = { repoId: "lattice" }) {
     provider: "lattice-graph",
     schemaVersion: 1,
     repo,
-    freshness: freshness()
+    freshness: freshness(),
+    nodes_by_kind: {},
+    edges_by_kind: {}
   };
 }
 


### PR DESCRIPTION
## Summary
- persist and report Python graph facts through the SQLite-backed graph provider status/query/search paths
- make file-targeted graph queries traverse nested Python symbols and classify Python test functions via attributes.isTest
- add Python store conformance coverage for status counts, freshness, FTS, named queries, impact, review-context, detect-changes, and incremental update/delete
- keep the local CI-equivalent cmdproof path read-only by restoring generated native package artifacts after npm run ci refreshes them

## Proof
- npx tsc -b --pretty false
- cargo fmt --check
- cargo test -p lattice-graph-core
- node --test tests/graph-store-conformance.test.mjs tests/graph-query-conformance.test.mjs tests/graph-search-conformance.test.mjs
- node --test tests/contracts.test.mjs tests/schema-contracts.test.mjs tests/validation-runner.test.mjs tests/validation-graph-client.test.mjs tests/validation-command-adapter.test.mjs tests/edit-symbols.test.mjs tests/edit-validation.test.mjs tests/validation-typescript.test.mjs tests/opcore-metrics.test.mjs
- zeroshot cmdproof check opcore-ci: reused_proof, profileContractStatus=passed, exitCode=0

Closes #18