### PR TITLE
test: prove Rust graph pipeline persistence

### DIFF
--- a/crates/graph-core/src/pipeline.rs
+++ b/crates/graph-core/src/pipeline.rs
@@ -468,14 +468,16 @@ fn attach_store_message(
             repo,
             freshness,
             db_path,
+            nodes_by_kind,
+            edges_by_kind,
             wal_checkpoint,
             ..
         } => available_status_with_wal_checkpoint(AvailableStatusInput {
             repo,
             freshness,
             db_path,
-            nodes_by_kind: None,
-            edges_by_kind: None,
+            nodes_by_kind: Some(nodes_by_kind),
+            edges_by_kind: Some(edges_by_kind),
             message: Some(format!(
                 "GraphProvider {operation} completed at {generated_at}"
             )),

--- a/crates/graph-core/src/protocol/tests.rs
+++ b/crates/graph-core/src/protocol/tests.rs
@@ -113,6 +113,8 @@ fn status_response_round_trips_with_handshake() -> TestResult {
 
     let value = serde_json::to_value(&response)?;
     assert_json_eq(&value, "/status/state", json!("available"));
+    assert_json_eq(&value, "/status/nodes_by_kind", json!({}));
+    assert_json_eq(&value, "/status/edges_by_kind", json!({}));
     assert_json_eq(
         &value,
         "/status/handshake/artifactName",

--- a/crates/graph-core/src/watch.rs
+++ b/crates/graph-core/src/watch.rs
@@ -149,6 +149,14 @@ fn watch_response_from_pipeline(
         Some("graph watch daemon available".to_string()),
     )?;
     session.log("available")?;
+    let (nodes_by_kind, edges_by_kind) = match &pipeline.status {
+        GraphProviderStatus::Available {
+            nodes_by_kind,
+            edges_by_kind,
+            ..
+        } => (Some(nodes_by_kind.clone()), Some(edges_by_kind.clone())),
+        _ => (None, None),
+    };
     pipeline.lifecycle = Some(lifecycle.clone());
     pipeline.status = available_status_with_wal_checkpoint(AvailableStatusInput {
         repo: session.repo.clone(),
@@ -156,8 +164,8 @@ fn watch_response_from_pipeline(
         db_path: Some(display_path(
             &repo_root.join(".lattice").join("graph").join("graph.db"),
         )),
-        nodes_by_kind: None,
-        edges_by_kind: None,
+        nodes_by_kind,
+        edges_by_kind,
         message: Some("graph watch daemon available".to_string()),
         wal_checkpoint: pipeline.summary.wal_checkpoint.clone(),
     });

--- a/tests/graph-pipeline-cli.test.mjs
+++ b/tests/graph-pipeline-cli.test.mjs
@@ -71,6 +71,61 @@ describe("graph pipeline CLI", () => {
     });
   });
 
+  it("builds, updates, watches, and reports status for Rust-only repos", () => {
+    const temp = mkdtempSync(join(tmpdir(), "lattice-graph-rust-only-"));
+    try {
+      writeRustOnlyRepo(temp);
+
+      const missing = run(latticeBin, ["graph", "status", "--repo", temp, "--json"]);
+      assert.equal(missing.providerStatus.state, "stale");
+      assert.equal(missing.providerStatus.failure.category, "stale_snapshot");
+      assert.equal(missing.providerStatus.walCheckpoint, undefined);
+      assert.equal(existsSync(join(temp, ".lattice")), false);
+
+      const build = run(latticeBin, ["graph", "build", "--repo", temp, "--json"]);
+      assert.equal(build.providerStatus.state, "available");
+      assert.equal(build.providerStatus.freshness.stale, false);
+      assert.ok(build.providerStatus.walCheckpoint);
+      assert.equal(build.graphPipeline.summary.discoveredFiles, 2);
+      assert.equal(build.graphPipeline.summary.parsedFiles, 2);
+      assert.deepEqual(build.graphPipeline.summary.changedFiles, ["src/lib.rs", "tests/widget_test.rs"]);
+
+      assertRustStoreRows(temp, { rustFiles: 2, requirePath: "tests/widget_test.rs" });
+
+      writeFileSync(
+        join(temp, "src/lib.rs"),
+        `${readFileSync(join(temp, "src/lib.rs"), "utf8")}\npub fn make_second_widget() -> Widget { Widget::new(\"second\") }\n`
+      );
+      unlinkSync(join(temp, "tests/widget_test.rs"));
+
+      const stale = run(latticeBin, ["graph", "status", "--repo", temp, "--json"]);
+      assert.equal(stale.providerStatus.state, "stale");
+      assert.match(stale.providerStatus.freshness.reason, /hash changed|removed/);
+
+      const update = run(latticeBin, ["graph", "update", "--repo", temp, "--base", "HEAD", "--json"]);
+      assert.equal(update.providerStatus.state, "available");
+      assert.equal(update.graphPipeline.summary.fullRebuildRequired, false);
+      assert.equal(update.graphPipeline.summary.parsedFiles, 1);
+      assert.deepEqual(update.graphPipeline.summary.changedFiles, ["src/lib.rs"]);
+      assert.deepEqual(update.graphPipeline.summary.deletedFiles, ["tests/widget_test.rs"]);
+      assertRustStoreRows(temp, { rustFiles: 1, requirePath: "src/lib.rs", missingPath: "tests/widget_test.rs" });
+
+      writeFileSync(join(temp, "src/extra.rs"), "pub fn extra() -> u64 { 2 }\n");
+      const watch = run(latticeBin, ["graph", "watch", "--repo", temp, "--once", "--poll-interval-ms", "50", "--json"]);
+      assert.equal(watch.providerStatus.state, "available");
+      assert.equal(watch.graphPipeline.summary.operation, "watch");
+      assert.deepEqual(watch.graphPipeline.summary.changedFiles, ["src/extra.rs"]);
+
+      const status = run(latticeBin, ["graph", "status", "--repo", temp, "--json"]);
+      assert.equal(status.providerStatus.state, "available");
+      assert.equal(status.providerStatus.freshness.stale, false);
+      assert.ok(status.providerStatus.walCheckpoint);
+      assertRustStoreRows(temp, { rustFiles: 2, requirePath: "src/extra.rs" });
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   it("runs watch once and writes daemon lifecycle artifacts", () => {
     withFixtureCopy((fixtureRoot) => {
       const watch = run(latticeBin, ["graph", "watch", "--repo", fixtureRoot, "--once", "--poll-interval-ms", "50", "--json"]);
@@ -777,6 +832,79 @@ function withNegatedGitignoreRepo(runFixture) {
     runFixture(fixtureRoot);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+function writeRustOnlyRepo(root) {
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, "tests"), { recursive: true });
+  writeFileSync(
+    join(root, "src/lib.rs"),
+    [
+      "pub trait Greeter {",
+      "    fn greet(&self) -> String;",
+      "}",
+      "",
+      "pub struct Widget {",
+      "    name: String,",
+      "}",
+      "",
+      "impl Widget {",
+      "    pub fn new(name: &str) -> Self {",
+      "        Self { name: name.to_string() }",
+      "    }",
+      "",
+      "    pub fn greet(&self) -> String {",
+      "        format!(\"hello {}\", self.name)",
+      "    }",
+      "}",
+      "",
+      "impl Greeter for Widget {",
+      "    fn greet(&self) -> String {",
+      "        self.greet()",
+      "    }",
+      "}",
+      "",
+      "pub fn make_widget() -> Widget {",
+      "    Widget::new(\"opcore\")",
+      "}",
+      "",
+      "#[cfg(test)]",
+      "mod tests {",
+      "    use super::*;",
+      "",
+      "    #[test]",
+      "    fn widget_smoke() {",
+      "        assert_eq!(make_widget().greet(), \"hello opcore\");",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
+  writeFileSync(
+    join(root, "tests/widget_test.rs"),
+    ["use opcore_fixture::make_widget;", "", "#[test]", "fn integration_smoke() {", "    let _ = make_widget();", "}", ""].join("\n")
+  );
+}
+
+function assertRustStoreRows(repoRoot, options) {
+  const db = new DatabaseSync(join(repoRoot, ".lattice/graph/graph.db"), { readOnly: true });
+  try {
+    assert.equal(db.prepare("select count(*) as count from file_hashes where language = 'rust'").get().count, options.rustFiles);
+    assert.ok(db.prepare("select count(*) as count from nodes").get().count > 0);
+    assert.ok(db.prepare("select count(*) as count from edges").get().count > 0);
+    assert.ok(db.prepare("select count(*) as count from nodes_fts").get().count > 0);
+    if (options.requirePath) {
+      assert.ok(db.prepare("select count(*) as count from nodes where path = ?").get(options.requirePath).count > 0);
+      assert.ok(db.prepare("select count(*) as count from nodes_fts where path = ?").get(options.requirePath).count > 0);
+    }
+    if (options.missingPath) {
+      assert.equal(db.prepare("select count(*) as count from file_hashes where relative_path = ?").get(options.missingPath).count, 0);
+      assert.equal(db.prepare("select count(*) as count from nodes where path = ?").get(options.missingPath).count, 0);
+      assert.equal(db.prepare("select count(*) as count from nodes_fts where path = ?").get(options.missingPath).count, 0);
+    }
+  } finally {
+    db.close();
   }
 }
 

--- a/tests/graph-store-conformance.test.mjs
+++ b/tests/graph-store-conformance.test.mjs
@@ -338,6 +338,86 @@ describe("GraphProvider SQLite store conformance", () => {
     });
   });
 
+  it("builds and incrementally updates Rust-only stores with freshness and FTS evidence", () => {
+    withRustOnlyRepo((fixtureRoot) => {
+      const missing = graphProviderStatus({ repoRoot: fixtureRoot });
+      assert.equal(missing.state, "stale");
+      assert.equal(missing.failure.category, "stale_snapshot");
+      assert.equal(missing.walCheckpoint, undefined);
+      assert.equal(existsSync(join(fixtureRoot, ".lattice")), false);
+
+      const build = graphProviderBuild({ repoRoot: fixtureRoot });
+      assert.equal(build.status.state, "available");
+      assert.equal(build.status.freshness.stale, false);
+      assert.equal(typeof build.status.freshness.generatedAt, "string");
+      assert.ok(build.status.walCheckpoint);
+      assert.equal(build.summary.discoveredFiles, 2);
+      assert.equal(build.summary.parsedFiles, 2);
+      assert.deepEqual(build.summary.changedFiles, ["src/lib.rs", "tests/widget_test.rs"]);
+      assert.equal(build.summary.fullRebuildRequired, false);
+      assert.ok(existsSync(build.status.dbPath));
+
+      const db = new DatabaseSync(build.status.dbPath, { readOnly: true });
+      try {
+        assert.equal(db.prepare("select count(*) as count from file_hashes where language = 'rust'").get().count, 2);
+        assert.ok(db.prepare("select count(*) as count from nodes").get().count > 0);
+        assert.ok(db.prepare("select count(*) as count from edges").get().count > 0);
+        assert.ok(db.prepare("select count(*) as count from nodes_fts").get().count > 0);
+        const nodeKinds = new Set(db.prepare("select distinct kind from nodes").all().map((row) => row.kind));
+        for (const kind of ["File", "Module", "Struct", "Trait", "Impl", "Function", "Method", "Test"]) {
+          assert.equal(nodeKinds.has(kind), true, kind);
+        }
+        assert.equal(db.prepare("select count(*) as count from nodes where id = ?").get("struct:src/lib.rs#Widget").count, 1);
+        assert.ok(db.prepare("select count(*) as count from nodes_fts where path = ?").get("src/lib.rs").count > 0);
+        assert.ok(
+          db.prepare("select count(*) as count from nodes_fts where path = ?").get("tests/widget_test.rs").count > 0
+        );
+      } finally {
+        db.close();
+      }
+
+      writeFileSync(
+        join(fixtureRoot, "src/lib.rs"),
+        `${readFileSync(join(fixtureRoot, "src/lib.rs"), "utf8")}\npub fn make_second_widget() -> Widget { Widget::new(\"second\") }\n`
+      );
+      unlinkSync(join(fixtureRoot, "tests/widget_test.rs"));
+
+      const stale = graphProviderStatus({ repoRoot: fixtureRoot });
+      assert.equal(stale.state, "stale");
+      assert.match(stale.freshness.reason, /hash changed|removed/);
+
+      const update = graphProviderUpdate({ repoRoot: fixtureRoot }, "HEAD");
+      assert.equal(update.status.state, "available");
+      assert.deepEqual(update.summary.changedFiles, ["src/lib.rs"]);
+      assert.deepEqual(update.summary.deletedFiles, ["tests/widget_test.rs"]);
+      assert.equal(update.summary.fullRebuildRequired, false);
+      assert.equal(update.summary.parsedFiles, 1);
+      assert.equal(update.summary.unchangedFiles, 0);
+
+      assertStoreMissingPath(update.status.dbPath, "tests/widget_test.rs");
+      const updatedDb = new DatabaseSync(update.status.dbPath, { readOnly: true });
+      try {
+        assert.equal(
+          updatedDb.prepare("select count(*) as count from nodes_fts where node_id = ?").get("function:src/lib.rs#make_second_widget")
+            .count,
+          1
+        );
+        const cached = JSON.parse(updatedDb.prepare("select value from lattice_store where key = 'file_facts_json'").get().value);
+        assert.equal(cached.some((facts) => facts.path === "src/lib.rs"), true);
+        assert.equal(cached.some((facts) => facts.path === "tests/widget_test.rs"), false);
+        const metadata = JSON.parse(
+          updatedDb.prepare("select value from lattice_store where key = 'search_index_last_update_json'").get().value
+        );
+        assert.equal(metadata.strategy, "incremental");
+        assert.deepEqual(metadata.changedFiles, ["src/lib.rs"]);
+        assert.deepEqual(metadata.deletedFiles, ["tests/widget_test.rs"]);
+        assert.ok(metadata.reindexedNodeIds.includes("function:src/lib.rs#make_second_widget"));
+      } finally {
+        updatedDb.close();
+      }
+    });
+  });
+
   it("stores absolute SQLite file paths when repoRoot is relative", () => {
     withFixtureCopy((fixtureRoot, tempRoot) => {
       const cwd = process.cwd();
@@ -613,6 +693,16 @@ function withPythonFixtureCopy(run) {
   }
 }
 
+function withRustOnlyRepo(run) {
+  const temp = mkdtempSync(join(tmpdir(), "lattice-store-rust-"));
+  try {
+    writeRustOnlyRepo(temp);
+    run(temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
 function withRobustnessFixtureCopy(run) {
   const temp = mkdtempSync(join(tmpdir(), "lattice-store-robustness-"));
   const fixtureRoot = join(temp, "watch-roots");
@@ -622,6 +712,58 @@ function withRobustnessFixtureCopy(run) {
   } finally {
     rmSync(temp, { recursive: true, force: true });
   }
+}
+
+function writeRustOnlyRepo(root) {
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, "tests"), { recursive: true });
+  writeFileSync(
+    join(root, "src/lib.rs"),
+    [
+      "pub trait Greeter {",
+      "    fn greet(&self) -> String;",
+      "}",
+      "",
+      "pub struct Widget {",
+      "    name: String,",
+      "}",
+      "",
+      "impl Widget {",
+      "    pub fn new(name: &str) -> Self {",
+      "        Self { name: name.to_string() }",
+      "    }",
+      "",
+      "    pub fn greet(&self) -> String {",
+      "        format!(\"hello {}\", self.name)",
+      "    }",
+      "}",
+      "",
+      "impl Greeter for Widget {",
+      "    fn greet(&self) -> String {",
+      "        self.greet()",
+      "    }",
+      "}",
+      "",
+      "pub fn make_widget() -> Widget {",
+      "    Widget::new(\"opcore\")",
+      "}",
+      "",
+      "#[cfg(test)]",
+      "mod tests {",
+      "    use super::*;",
+      "",
+      "    #[test]",
+      "    fn widget_smoke() {",
+      "        assert_eq!(make_widget().greet(), \"hello opcore\");",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
+  writeFileSync(
+    join(root, "tests/widget_test.rs"),
+    ["use opcore_fixture::make_widget;", "", "#[test]", "fn integration_smoke() {", "    let _ = make_widget();", "}", ""].join("\n")
+  );
 }
 
 function createRuntimeIgnoredFiles(fixtureRoot) {

--- a/tests/installed-bins.test.mjs
+++ b/tests/installed-bins.test.mjs
@@ -554,7 +554,7 @@ function createOnboardingFixtures(root) {
         "src/lib.rs": "pub fn answer() -> usize {\n    42\n}\n"
       },
       coverage: {
-        Rust: { files: 2, graphSupported: false, validationSupported: true }
+        Rust: { files: 2, graphSupported: true, graphSupportedFiles: 1, validationSupported: true }
       },
       scanEnv: sourceSafeOpcoreEnv()
     }),
@@ -566,7 +566,7 @@ function createOnboardingFixtures(root) {
       },
       coverage: {
         TypeScript: { files: 1, graphSupported: true, validationSupported: true },
-        Rust: { files: 2, graphSupported: false, validationSupported: true }
+        Rust: { files: 2, graphSupported: true, graphSupportedFiles: 1, validationSupported: true }
       },
       scanEnv: sourceSafeOpcoreEnv()
     }),
@@ -688,8 +688,13 @@ function expectedFixtureTotalFiles(fixture) {
 
 function expectedFixtureFiles(fixture, key) {
   return Object.values(fixture.coverage)
-    .filter((entry) => entry[key])
-    .reduce((sum, entry) => sum + entry.files, 0);
+    .reduce((sum, entry) => sum + expectedCoverageFiles(entry, key), 0);
+}
+
+function expectedCoverageFiles(entry, key) {
+  const countKey = `${key}Files`;
+  if (Number.isInteger(entry[countKey])) return entry[countKey];
+  return entry[key] ? entry.files : 0;
 }
 
 function snapshotFiles(repoRoot, paths) {
@@ -808,9 +813,7 @@ function fixtureRepoShape(fixture) {
     files: expected.files
   }));
   const totalFiles = languages.reduce((sum, entry) => sum + entry.files, 0);
-  const graphSupportedFiles = Object.values(fixture.coverage)
-    .filter((entry) => entry.graphSupported)
-    .reduce((sum, entry) => sum + entry.files, 0);
+  const graphSupportedFiles = expectedFixtureFiles(fixture, "graphSupported");
   return {
     totalFiles,
     languages,

--- a/tests/opcore-facade.test.mjs
+++ b/tests/opcore-facade.test.mjs
@@ -126,6 +126,7 @@ describe("opcore public facade", () => {
       );
       writeFileSync(join(temp, "src/lib.rs"), "pub fn value() -> u64 { 1 }\n");
 
+      const before = collectRepoPaths(temp);
       const result = parseJson(runOpcore(["status", "--repo", temp, "--json"], temp, 0).stdout);
       const coverage = result.repoState.coverage;
 
@@ -136,8 +137,21 @@ describe("opcore public facade", () => {
       assert.equal(coverage.graph.supportedFiles, 1);
       assert.deepEqual(coverage.graph.extensions, [{ extension: ".rs", count: 1 }]);
       assert.equal(coverage.validation.supportedFiles, 2);
+      assert.deepEqual(Object.fromEntries(coverage.validation.extensions.map((entry) => [entry.extension, entry.count])), {
+        ".rs": 1,
+        "Cargo.toml": 1
+      });
       assert.equal(coverage.unsupported.totalFiles, 0);
       assert.deepEqual(coverage.unsupported.stacks, []);
+      assert.equal(result.repoState.graph.state, "stale");
+      assert.equal(result.repoState.graph.status.failure.category, "stale_snapshot");
+      assert.equal(result.repoState.graph.status.walCheckpoint, undefined);
+      assert.equal(existsSync(join(temp, ".lattice")), false);
+
+      const human = runOpcore(["status", "--repo", temp], temp, 0);
+      assert.match(human.stdout, /Coverage: files=2 graph=1 validation=2 retained=0 unsupported=none/);
+      assert.match(human.stdout, /Validation: checks=\d+ adapters=.*degradedRustTools=/);
+      assert.deepEqual(collectRepoPaths(temp), before);
     } finally {
       rmSync(temp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add Rust-only SQLite store conformance proving non-empty Rust nodes/edges/file_hashes/nodes_fts plus freshness and WAL evidence
- add Rust-only lattice graph CLI build/update/watch/status coverage, including changed/deleted .rs files and stale missing-store behavior
- tighten Opcore status coverage for Rust graph-vs-validation counts while asserting status remains read-only

Closes #26

## Verification
- npm run build
- npm run rust:check
- node --test tests/graph-store-conformance.test.mjs tests/graph-pipeline-cli.test.mjs tests/opcore-facade.test.mjs tests/opcore-metrics.test.mjs
- node scripts/check-workspace.mjs
- npm run pack:check
- node --test tests/contracts.test.mjs tests/schema-contracts.test.mjs
- git diff --check

## Notes
- No public release, npm publish, visibility change, announcement, registry/certification claim, or release artifact push.
- Local build regenerates the current-platform native graph-core package for test proof; generated native package files were restored and are not included in this PR.