### PR TITLE
feat: prove Rust graph query parity

### DIFF
--- a/crates/graph-core/src/search.rs
+++ b/crates/graph-core/src/search.rs
@@ -375,9 +375,19 @@ fn project_node(node: &GraphFactNode) -> SearchIndexRow {
 fn signature_for_node(node: &GraphFactNode, name: Option<&str>) -> String {
     let repo_path = node.path.as_deref().unwrap_or("");
     let display_name = name.unwrap_or(repo_path);
+    let extracted_signature = node
+        .attributes
+        .as_ref()
+        .and_then(|attributes| attributes.get("signature"))
+        .and_then(serde_json::Value::as_str)
+        .map(searchable_text)
+        .unwrap_or_default();
     let split_name = searchable_text(display_name);
     let qualified = searchable_text(&node.id);
-    format!("{} {} {} {}", node.kind, split_name, repo_path, qualified)
+    format!(
+        "{} {} {} {} {}",
+        node.kind, split_name, repo_path, qualified, extracted_signature
+    )
 }
 
 fn searchable_text(value: &str) -> String {

--- a/packages/opcore/src/lattice/inspect-adapter.ts
+++ b/packages/opcore/src/lattice/inspect-adapter.ts
@@ -4,13 +4,17 @@ import type {
   CommandAdapterRequest,
   CommandRouterResult,
   CommandRouteStatus,
+  GraphFactEdge,
+  GraphFactNode,
   GraphFactQuerySelector,
   GraphFactQueryResult,
   GraphProviderStatus,
   InspectFailureCategory,
+  InspectReferenceEntry,
   InspectRouteFailure,
   InspectRouteResult,
   InspectSymbolTarget,
+  InspectTextSpan,
   RepoIdentity
 } from "@the-open-engine/opcore-contracts";
 import { createCommandRouterResult } from "@the-open-engine/opcore-contracts";
@@ -133,6 +137,9 @@ function inspectNodeReferencesResult(request: CommandAdapterRequest, options: In
   if (!parsed) {
     return inspectFailureResult(request, "references", "target_not_found", `Inspect references node target is not a supported class/function/type node: ${nodeId}`, graphQuery.status, target, graphQuery);
   }
+  if (isRustInspectSourcePath(parsed.path)) {
+    return inspectRustGraphReferencesResult(request, options, target, candidate);
+  }
   if (!isSupportedInspectSourcePath(parsed.path)) {
     return inspectFailureResult(request, "references", "unsupported_language", `Unsupported inspect references target language: ${parsed.path}`, graphQuery.status, target, graphQuery);
   }
@@ -192,6 +199,9 @@ function inspectFileSymbolReferencesResult(
   }
   if (!target.path || !target.symbolName) {
     return inspectFailureResult(request, "references", "malformed_target", "lattice inspect references requires <file> <symbol>");
+  }
+  if (isRustInspectSourcePath(target.path)) {
+    return inspectRustFileSymbolReferencesResult(request, options, target, graphQuery);
   }
   if (!isSupportedInspectSourcePath(target.path)) {
     return inspectFailureResult(request, "references", "unsupported_language", `Unsupported inspect references target language: ${target.path}`, graphQuery.status, target, graphQuery);
@@ -260,6 +270,16 @@ function inspectNodeSignatureResult(request: CommandAdapterRequest, options: Ins
   if (!parsed) {
     return inspectFailureResult(request, "signature", "target_not_found", `Inspect signature node target is not a supported class/function/type node: ${nodeId}`, graphQuery.status, target, graphQuery);
   }
+  if (isRustInspectSourcePath(parsed.path)) {
+    return inspectUnsupportedRouteResult(
+      request,
+      "signature",
+      "Rust inspect signature requires language-service materialization and is not supported yet.",
+      graphQuery.status,
+      graphTargetForNode(target, candidate),
+      graphQuery
+    );
+  }
   if (!isSupportedInspectSourcePath(parsed.path)) {
     return inspectFailureResult(request, "signature", "unsupported_language", `Unsupported inspect signature target language: ${parsed.path}`, graphQuery.status, target, graphQuery);
   }
@@ -318,6 +338,16 @@ function inspectFileSymbolSignatureResult(
   if (!target.path || !target.symbolName) {
     return inspectFailureResult(request, "signature", "malformed_target", "lattice inspect signature requires <file> <symbol>");
   }
+  if (isRustInspectSourcePath(target.path)) {
+    return inspectUnsupportedRouteResult(
+      request,
+      "signature",
+      "Rust inspect signature requires language-service materialization and is not supported yet.",
+      graphQuery.status,
+      rustGraphCandidateForFileSymbol(graphQuery, target) ?? target,
+      graphQuery
+    );
+  }
   if (!isSupportedInspectSourcePath(target.path)) {
     return inspectFailureResult(request, "signature", "unsupported_language", `Unsupported inspect signature target language: ${target.path}`, graphQuery.status, target, graphQuery);
   }
@@ -375,6 +405,28 @@ function inspectImplementationsResult(request: CommandAdapterRequest, options: I
   }
   if (!("nodes" in graphQuery) || !("edges" in graphQuery)) {
     return inspectFailureResult(request, "implementations", "graph_unavailable", "Graph provider returned no symbol facts", graphQuery.status, target.target, graphQuery);
+  }
+  const implementationNodeTarget =
+    target.target.kind === "node" ? graphQuery.nodes.find((node) => node.id === target.target.nodeId) : undefined;
+  if (implementationNodeTarget?.path && isRustInspectSourcePath(implementationNodeTarget.path)) {
+    return inspectUnsupportedRouteResult(
+      request,
+      "implementations",
+      "Rust inspect implementations requires language-service materialization and is not supported yet.",
+      graphQuery.status,
+      graphTargetForNode(target.target, implementationNodeTarget),
+      graphQuery
+    );
+  }
+  if (target.target.kind === "file_symbol" && target.target.path && isRustInspectSourcePath(target.target.path)) {
+    return inspectUnsupportedRouteResult(
+      request,
+      "implementations",
+      "Rust inspect implementations requires language-service materialization and is not supported yet.",
+      graphQuery.status,
+      rustGraphCandidateForFileSymbol(graphQuery, target.target) ?? target.target,
+      graphQuery
+    );
   }
   if (!graphQuery.metadata.edgeKinds.includes("IMPLEMENTS") || !graphQuery.metadata.edgeKinds.includes("INHERITS")) {
     return inspectFailureResult(
@@ -501,6 +553,38 @@ function inspectFailureResult(
   });
 }
 
+function inspectUnsupportedRouteResult(
+  request: CommandAdapterRequest,
+  route: InspectRouteResult["route"],
+  message: string,
+  providerStatus?: GraphProviderStatus,
+  target?: InspectSymbolTarget,
+  graphQuery?: GraphFactQueryResult
+): CommandRouterResult {
+  const failure: InspectRouteFailure = {
+    category: "unsupported_route",
+    message
+  };
+  return createCommandRouterResult({
+    bin: request.bin,
+    argv: request.argv,
+    canonicalCommand: request.canonicalCommand,
+    owner: "inspect",
+    status: "unsupported",
+    json: request.json,
+    message,
+    providerStatus,
+    graphQuery,
+    inspectResult: {
+      route,
+      status: "degraded",
+      ...(target ? { target } : {}),
+      ...(providerStatus ? { providerStatus } : {}),
+      failure
+    }
+  });
+}
+
 function inspectStatus(status: GraphProviderStatus): CommandRouteStatus {
   return status.state === "available" ? "ok" : "error";
 }
@@ -530,6 +614,233 @@ function graphNodeTarget(
   const symbolName = name ?? parsed?.[2];
   if (!targetPath || !symbolName) return undefined;
   return { path: targetPath, symbolName };
+}
+
+function inspectRustGraphReferencesResult(
+  request: CommandAdapterRequest,
+  options: InspectOptions,
+  target: InspectSymbolTarget,
+  candidate: GraphFactNode
+): CommandRouterResult {
+  const graphQuery = graphProviderQuery(options.repo, {
+    kind: "neighbors",
+    ids: [candidate.id],
+    edgeKinds: ["CALLS", "TESTED_BY"],
+    limit: options.limit ?? 100
+  });
+  if (graphQuery.status.state !== "available") {
+    return inspectFailureResult(
+      request,
+      "references",
+      "graph_unavailable",
+      graphQuery.status.message ?? `Graph provider is ${graphQuery.status.state}`,
+      graphQuery.status,
+      graphTargetForNode(target, candidate),
+      graphQuery
+    );
+  }
+  if (!("nodes" in graphQuery) || !("edges" in graphQuery)) {
+    return inspectFailureResult(
+      request,
+      "references",
+      "graph_unavailable",
+      "Graph provider returned no Rust reference facts",
+      graphQuery.status,
+      graphTargetForNode(target, candidate),
+      graphQuery
+    );
+  }
+  const references = rustGraphReferences(candidate, graphQuery.nodes, graphQuery.edges, options.limit);
+  return createCommandRouterResult({
+    bin: request.bin,
+    argv: request.argv,
+    canonicalCommand: request.canonicalCommand,
+    owner: "inspect",
+    status: "ok",
+    json: request.json,
+    message: "lattice inspect references: graph provider returned read-only Rust references.",
+    providerStatus: graphQuery.status,
+    graphQuery,
+    inspectResult: {
+      route: "references",
+      status: "ok",
+      target: graphTargetForNode(target, candidate),
+      providerStatus: graphQuery.status,
+      references
+    }
+  });
+}
+
+function inspectRustFileSymbolReferencesResult(
+  request: CommandAdapterRequest,
+  options: InspectOptions,
+  target: InspectSymbolTarget,
+  graphQuery: GraphFactQueryResult
+): CommandRouterResult {
+  if (!("nodes" in graphQuery)) {
+    return inspectFailureResult(request, "references", "graph_unavailable", "Graph provider returned no symbol nodes", graphQuery.status, target, graphQuery);
+  }
+  const candidates = rustGraphCandidatesForFileSymbol(graphQuery, target);
+  if (candidates.length === 0) {
+    return inspectFailureResult(
+      request,
+      "references",
+      "target_not_found",
+      `Inspect references Rust target not found in graph facts: ${target.path ?? ""} ${target.symbolName ?? ""}`.trim(),
+      graphQuery.status,
+      target,
+      graphQuery
+    );
+  }
+  if (candidates.length > 1) {
+    return inspectFailureResult(
+      request,
+      "references",
+      "target_ambiguous",
+      `Ambiguous inspect references Rust target "${target.symbolName ?? ""}" in ${target.path ?? ""}`,
+      graphQuery.status,
+      target,
+      graphQuery,
+      { candidates: candidates.map((candidate) => graphTargetForNode(target, candidate)) }
+    );
+  }
+  return inspectRustGraphReferencesResult(request, options, target, candidates[0]);
+}
+
+function rustGraphReferences(
+  target: GraphFactNode,
+  nodes: readonly GraphFactNode[],
+  edges: readonly GraphFactEdge[],
+  limit: number | undefined
+): readonly InspectReferenceEntry[] {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  nodesById.set(target.id, target);
+  const targetSymbol = inspectSymbolSummary(target);
+  const entries: InspectReferenceEntry[] = [inspectReferenceEntry(target, targetSymbol, [target.id], true)];
+  const seen = new Set([target.id]);
+  for (const edge of [...edges].sort(compareGraphReferenceEdges)) {
+    const referenceNodeId =
+      edge.kind === "CALLS" && edge.to === target.id
+        ? edge.from
+        : edge.kind === "TESTED_BY" && edge.from === target.id
+          ? edge.to
+          : undefined;
+    if (!referenceNodeId || seen.has(referenceNodeId)) continue;
+    const referenceNode = nodesById.get(referenceNodeId);
+    if (!referenceNode) continue;
+    seen.add(referenceNodeId);
+    entries.push(inspectReferenceEntry(referenceNode, targetSymbol, [target.id, referenceNode.id], false));
+  }
+  return limit === undefined ? entries : entries.slice(0, limit);
+}
+
+function inspectReferenceEntry(
+  node: GraphFactNode,
+  symbol: InspectReferenceEntry["symbol"],
+  graphNodeIds: readonly string[],
+  isDefinition: boolean
+): InspectReferenceEntry {
+  const span = spanFromGraphNode(node);
+  return {
+    file: node.path ?? pathFromGraphNodeId(node.id),
+    line: span.startLine,
+    column: span.startColumn,
+    text: node.name ?? node.id,
+    span,
+    symbol,
+    isDefinition,
+    isDeclaration: true,
+    evidence: {
+      graphNodeIds,
+      resolver: "graph"
+    }
+  };
+}
+
+function spanFromGraphNode(node: GraphFactNode): InspectTextSpan {
+  const attributes = graphNodeAttributes(node);
+  const startLine = positiveAttribute(attributes, "lineStart", 1);
+  const startColumn = positiveAttribute(attributes, "columnStart", 0) + 1;
+  const endLine = positiveAttribute(attributes, "lineEnd", startLine);
+  const rawEndColumn = positiveAttribute(attributes, "columnEnd", startColumn - 1) + 1;
+  const endColumn = endLine === startLine && rawEndColumn < startColumn ? startColumn : rawEndColumn;
+  return {
+    startLine,
+    startColumn,
+    endLine,
+    endColumn
+  };
+}
+
+function graphNodeAttributes(node: GraphFactNode): Record<string, unknown> {
+  return node.attributes && typeof node.attributes === "object" && !Array.isArray(node.attributes)
+    ? (node.attributes as Record<string, unknown>)
+    : {};
+}
+
+function positiveAttribute(attributes: Record<string, unknown>, key: string, fallback: number): number {
+  const value = attributes[key];
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : fallback;
+}
+
+function inspectSymbolSummary(node: GraphFactNode): InspectReferenceEntry["symbol"] {
+  return {
+    id: node.id,
+    name: node.name ?? node.id,
+    kind: node.kind
+  };
+}
+
+function graphTargetForNode(base: InspectSymbolTarget, node: GraphFactNode): InspectSymbolTarget {
+  if (base.kind === "node") {
+    return {
+      kind: "node",
+      nodeId: node.id
+    };
+  }
+  return {
+    ...base,
+    nodeId: node.id,
+    path: node.path ?? base.path,
+    symbolName: node.name ?? base.symbolName
+  };
+}
+
+function rustGraphCandidateForFileSymbol(
+  graphQuery: GraphFactQueryResult,
+  target: InspectSymbolTarget
+): InspectSymbolTarget | undefined {
+  if (!("nodes" in graphQuery)) return undefined;
+  const [candidate] = rustGraphCandidatesForFileSymbol(graphQuery, target);
+  return candidate ? graphTargetForNode(target, candidate) : undefined;
+}
+
+function rustGraphCandidatesForFileSymbol(graphQuery: GraphFactQueryResult, target: InspectSymbolTarget): GraphFactNode[] {
+  if (!("nodes" in graphQuery) || !target.path || !target.symbolName) return [];
+  return graphQuery.nodes
+    .filter((node) => node.path === target.path)
+    .filter((node) => node.name === target.symbolName || graphNodeQualifiedName(node) === target.symbolName)
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function graphNodeQualifiedName(node: GraphFactNode): string | undefined {
+  const attributes = graphNodeAttributes(node);
+  const qualifiedName = attributes.qualifiedName;
+  if (typeof qualifiedName === "string") return qualifiedName;
+  return node.id.split("#").at(1);
+}
+
+function pathFromGraphNodeId(nodeId: string): string {
+  const afterKind = nodeId.split(":").slice(1).join(":");
+  return afterKind.split("#")[0] || nodeId;
+}
+
+function compareGraphReferenceEdges(left: GraphFactEdge, right: GraphFactEdge): number {
+  return left.kind.localeCompare(right.kind) || left.from.localeCompare(right.from) || left.to.localeCompare(right.to);
+}
+
+function isRustInspectSourcePath(path: string): boolean {
+  return path.toLowerCase().endsWith(".rs");
 }
 
 function parseInspectSymbolTarget(

--- a/tests/graph-query-cli.test.mjs
+++ b/tests/graph-query-cli.test.mjs
@@ -57,6 +57,43 @@ describe("graph query CLI routes", () => {
       assert.equal(search.graphSearch.results[0].path, "src/components/GreetingCard.tsx");
     });
   });
+
+  it("routes Rust query, impact, review-context, detect-changes, and search through canonical lattice commands", () => {
+    withBuiltRustFixture((fixtureRoot) => {
+      const query = run(latticeBin, [
+        "graph",
+        "query",
+        "callers_of",
+        "function:src/helpers.rs#helpers::assist",
+        "--repo",
+        fixtureRoot,
+        "--json"
+      ]);
+      assert.equal(query.status, "ok");
+      assert.ok(query.graphQuery.nodes.some((node) => node.id === "function:src/consumer.rs#consumer::run"));
+
+      const impact = run(latticeBin, ["graph", "impact", "--repo", fixtureRoot, "--files", "src/helpers.rs", "--max-depth", "3", "--json"]);
+      assert.equal(impact.status, "ok");
+      assert.deepEqual(impact.graphImpact.changedFiles, ["src/helpers.rs"]);
+      assert.ok(impact.graphImpact.impactedFiles.includes("src/consumer.rs"));
+      assert.ok(impact.graphImpact.tests.includes("src/consumer.rs"));
+
+      const review = run(latticeBin, ["graph", "review-context", "--repo", fixtureRoot, "--files", "src/helpers.rs", "--json"]);
+      assert.equal(review.status, "ok");
+      assert.ok(review.graphReviewContext.impactedFiles.includes("src/consumer.rs"));
+      assert.ok(review.graphReviewContext.tests.includes("src/consumer.rs"));
+
+      const changes = run(latticeBin, ["graph", "detect-changes", "--repo", fixtureRoot, "--files", "src/helpers.rs", "--json"]);
+      assert.equal(changes.status, "ok");
+      assert.deepEqual(changes.graphChanges.changedFiles, ["src/helpers.rs"]);
+      assert.deepEqual(changes.graphChanges.deletedFiles, []);
+
+      const search = run(latticeBin, ["graph", "search", "pub struct Widget", "--repo", fixtureRoot, "--limit", "5", "--json"]);
+      assert.equal(search.status, "ok");
+      assert.equal(search.graphSearch.results[0].nodeId, "struct:src/lib.rs#Widget");
+      assert.match(search.graphSearch.results[0].signature, /\bpub struct Widget\b/);
+    });
+  });
 });
 
 describe("graph query CLI freshness failures", () => {
@@ -193,6 +230,66 @@ function withBuiltFixture(runFixture) {
   } finally {
     rmSync(temp, { recursive: true, force: true });
   }
+}
+
+function withBuiltRustFixture(runFixture) {
+  const temp = mkdtempSync(join(tmpdir(), "lattice-query-cli-rust-"));
+  try {
+    writeRustFixture(temp);
+    run(latticeBin, ["graph", "build", "--repo", temp, "--json"]);
+    runFixture(temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function writeRustFixture(root) {
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src/lib.rs"),
+    [
+      "pub mod helpers;",
+      "pub mod consumer;",
+      "",
+      "pub trait Service {",
+      "    fn handle(&self) -> String;",
+      "}",
+      "",
+      "pub struct Widget;",
+      "",
+      "impl Widget {",
+      "    pub fn new() -> Self {",
+      "        Widget",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
+  writeFileSync(join(root, "src/helpers.rs"), "pub fn assist() -> String { \"ok\".to_string() }\n");
+  writeFileSync(
+    join(root, "src/consumer.rs"),
+    [
+      "use crate::helpers;",
+      "use crate::{Service, Widget};",
+      "",
+      "pub fn run() -> String {",
+      "    let widget = Widget::new();",
+      "    helpers::assist();",
+      "    widget.handle()",
+      "}",
+      "",
+      "#[cfg(test)]",
+      "mod tests {",
+      "    use super::*;",
+      "",
+      "    #[test]",
+      "    fn test_run() {",
+      "        assert_eq!(run(), \"ok\");",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
 }
 
 function run(script, args, expectedStatus = 0) {

--- a/tests/graph-query-conformance.test.mjs
+++ b/tests/graph-query-conformance.test.mjs
@@ -129,6 +129,64 @@ describe("GraphProvider query conformance", () => {
     });
   });
 
+  it("returns Rust named query, impact, detect-changes, and review-context facts", () => {
+    withRustFixture((fixtureRoot) => {
+      const build = graphProviderBuild({ repoRoot: fixtureRoot });
+      assert.equal(build.status.state, "available");
+
+      const callers = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "callers_of", target: "function:src/helpers.rs#helpers::assist", maxDepth: 1, limit: 100 }
+      );
+      assert.equal(callers.status.state, "available");
+      assert.ok(callers.nodes.map((node) => node.id).includes("function:src/consumer.rs#consumer::run"));
+      assert.ok(callers.edges.some((edge) => edge.kind === "CALLS" && edge.from === "function:src/consumer.rs#consumer::run"));
+
+      const importers = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "importers_of", target: "src/helpers.rs", maxDepth: 2, limit: 100 }
+      );
+      assert.equal(importers.status.state, "available");
+      assert.deepEqual(paths(importers.nodes), ["src/consumer.rs", "src/helpers.rs"]);
+
+      const tests = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "tests_for", target: "src/consumer.rs", maxDepth: 1, limit: 100 }
+      );
+      assert.equal(tests.status.state, "available");
+      assert.ok(tests.nodes.map((node) => node.id).includes("test:src/consumer.rs#consumer.tests::test_run"));
+      assert.ok(paths(tests.nodes).includes("src/consumer.rs"));
+
+      const children = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "children_of", target: "src/lib.rs", maxDepth: 2, limit: 100 }
+      );
+      assert.equal(children.status.state, "available");
+      assert.ok(children.nodes.map((node) => node.id).includes("struct:src/lib.rs#Widget"));
+      assert.ok(children.nodes.map((node) => node.id).includes("trait:src/lib.rs#Service"));
+
+      const impact = graphProviderImpact({ repoRoot: fixtureRoot }, { files: ["src/helpers.rs"], maxDepth: 3, limit: 100 });
+      assert.equal(impact.status.state, "available");
+      assert.deepEqual(impact.changedFiles, ["src/helpers.rs"]);
+      assert.ok(impact.impactedFiles.includes("src/consumer.rs"));
+      assert.ok(impact.impactedSymbols.includes("function:src/helpers.rs#helpers::assist"));
+      assert.ok(impact.impactedSymbols.includes("function:src/consumer.rs#consumer::run"));
+      assert.ok(impact.tests.includes("src/consumer.rs"));
+      assert.equal(impact.traversal.truncated, false);
+
+      const changes = graphProviderDetectChanges({ repoRoot: fixtureRoot }, { files: ["src/helpers.rs"] });
+      assert.equal(changes.status.state, "available");
+      assert.deepEqual(changes.changedFiles, ["src/helpers.rs"]);
+      assert.deepEqual(changes.deletedFiles, []);
+
+      const review = graphProviderReviewContext({ repoRoot: fixtureRoot }, { files: ["src/helpers.rs"], maxDepth: 3 });
+      assert.equal(review.status.state, "available");
+      assert.deepEqual(review.changedFiles, ["src/helpers.rs"]);
+      assert.ok(review.impactedFiles.includes("src/consumer.rs"));
+      assert.ok(review.tests.includes("src/consumer.rs"));
+    });
+  });
+
   it("normalizes duplicate separators in query file consumers", () => {
     withBuiltFixture((fixtureRoot) => {
       const changes = graphProviderDetectChanges({ repoRoot: fixtureRoot }, { files: ["src//models.ts"] });
@@ -192,6 +250,71 @@ function withBuiltFixture(runFixture) {
   } finally {
     rmSync(temp, { recursive: true, force: true });
   }
+}
+
+function withRustFixture(runFixture) {
+  const temp = mkdtempSync(join(tmpdir(), "lattice-query-rust-"));
+  try {
+    writeRustFixture(temp);
+    runFixture(temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function writeRustFixture(root) {
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src/lib.rs"),
+    [
+      "pub mod helpers;",
+      "pub mod consumer;",
+      "",
+      "pub trait Service {",
+      "    fn handle(&self) -> String;",
+      "}",
+      "",
+      "pub struct Widget;",
+      "",
+      "impl Widget {",
+      "    pub fn new() -> Self {",
+      "        Widget",
+      "    }",
+      "}",
+      "",
+      "impl Service for Widget {",
+      "    fn handle(&self) -> String {",
+      "        helpers::assist()",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
+  writeFileSync(join(root, "src/helpers.rs"), "pub fn assist() -> String { \"ok\".to_string() }\n");
+  writeFileSync(
+    join(root, "src/consumer.rs"),
+    [
+      "use crate::helpers;",
+      "use crate::{Service, Widget};",
+      "",
+      "pub fn run() -> String {",
+      "    let widget = Widget::new();",
+      "    helpers::assist();",
+      "    widget.handle()",
+      "}",
+      "",
+      "#[cfg(test)]",
+      "mod tests {",
+      "    use super::*;",
+      "",
+      "    #[test]",
+      "    fn test_run() {",
+      "        assert_eq!(run(), \"ok\");",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
 }
 
 function skipGeneratedStore(source) {

--- a/tests/graph-search-conformance.test.mjs
+++ b/tests/graph-search-conformance.test.mjs
@@ -123,6 +123,25 @@ describe("GraphProvider search conformance", () => {
     });
   });
 
+  it("indexes and ranks Rust symbol signatures deterministically", () => {
+    withRustFixture((fixtureRoot) => {
+      const build = graphProviderBuild({ repoRoot: fixtureRoot });
+      assert.equal(build.status.state, "available");
+
+      const result = graphProviderSearch({ repoRoot: fixtureRoot }, { query: "pub struct Widget", limit: 5 });
+      assert.equal(result.status.state, "available");
+      assert.equal(result.searchMode.engine, "fts5");
+      assert.equal(result.results[0].nodeId, "struct:src/lib.rs#Widget");
+      assert.equal(result.results[0].kind, "Struct");
+      assert.match(result.results[0].signature, /\bpub struct Widget\b/);
+      assert.ok(result.results[0].matches.includes("signature"));
+      assert.deepEqual(
+        result.results.map((entry) => entry.nodeId).slice(0, 3),
+        ["struct:src/lib.rs#Widget"]
+      );
+    });
+  });
+
   it("returns typed failures without search rows for missing schema and stale stores", () => {
     const missingRepo = mkdtempSync(join(tmpdir(), "lattice-search-missing-"));
     try {
@@ -230,6 +249,65 @@ function withFixtureCopy(run) {
   } finally {
     rmSync(temp, { recursive: true, force: true });
   }
+}
+
+function withRustFixture(run) {
+  const temp = mkdtempSync(join(tmpdir(), "lattice-search-rust-"));
+  try {
+    writeRustFixture(temp);
+    run(temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function writeRustFixture(root) {
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src/lib.rs"),
+    [
+      "pub mod helpers;",
+      "pub mod consumer;",
+      "",
+      "pub trait Service {",
+      "    fn handle(&self) -> String;",
+      "}",
+      "",
+      "pub struct Widget;",
+      "",
+      "impl Widget {",
+      "    pub fn new() -> Self {",
+      "        Widget",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
+  writeFileSync(join(root, "src/helpers.rs"), "pub fn assist() -> String { \"ok\".to_string() }\n");
+  writeFileSync(
+    join(root, "src/consumer.rs"),
+    [
+      "use crate::helpers;",
+      "use crate::{Service, Widget};",
+      "",
+      "pub fn run() -> String {",
+      "    let widget = Widget::new();",
+      "    helpers::assist();",
+      "    widget.handle()",
+      "}",
+      "",
+      "#[cfg(test)]",
+      "mod tests {",
+      "    use super::*;",
+      "",
+      "    #[test]",
+      "    fn test_run() {",
+      "        assert_eq!(run(), \"ok\");",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
 }
 
 function skipGeneratedStore(source) {

--- a/tests/inspect-references.test.mjs
+++ b/tests/inspect-references.test.mjs
@@ -1,6 +1,6 @@
 import { it } from "node:test";
 import assert from "node:assert/strict";
-import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -88,6 +88,61 @@ it("preserves node-id references with graphQuery and typed inspectResult", async
     assert.equal(result.inspectResult.target.nodeId, nodeId);
     assert.equal(Object.hasOwn(result, "alias"), false);
     assert.equal(Object.hasOwn(result, removedLegacyCommandField), false);
+  });
+});
+
+it("returns Rust graph-backed references and degrades unsupported Rust signature materialization", async () => {
+  await withRustInspectFixture(async (fixtureRoot) => {
+    await buildGraph(fixtureRoot);
+
+    const references = await routeCommand([
+      "inspect",
+      "references",
+      "function:src/helpers.rs#helpers::assist",
+      "--repo",
+      fixtureRoot,
+      "--json"
+    ], "lattice");
+    assert.equal(references.owner, "inspect");
+    assert.equal(references.status, "ok");
+    assert.equal(references.providerStatus.state, "available");
+    assert.equal(references.inspectResult.status, "ok");
+    assert.equal(references.inspectResult.target.nodeId, "function:src/helpers.rs#helpers::assist");
+    assert.equal(references.inspectResult.references.some((reference) => reference.evidence.resolver === "graph"), true);
+    assert.equal(
+      references.inspectResult.references.some((reference) =>
+        reference.evidence.graphNodeIds.includes("function:src/consumer.rs#consumer::run")
+      ),
+      true
+    );
+
+    const signature = await routeCommand([
+      "inspect",
+      "signature",
+      "struct:src/lib.rs#Widget",
+      "--repo",
+      fixtureRoot,
+      "--json"
+    ], "lattice");
+    assert.equal(signature.owner, "inspect");
+    assert.equal(signature.status, "unsupported");
+    assert.equal(signature.inspectResult.status, "degraded");
+    assert.equal(signature.inspectResult.failure.category, "unsupported_route");
+    assert.equal(Object.hasOwn(signature.inspectResult, "signatures"), false);
+
+    const implementations = await routeCommand([
+      "inspect",
+      "implementations",
+      "trait:src/lib.rs#Service",
+      "--repo",
+      fixtureRoot,
+      "--json"
+    ], "lattice");
+    assert.equal(implementations.owner, "inspect");
+    assert.equal(implementations.status, "unsupported");
+    assert.equal(implementations.inspectResult.status, "degraded");
+    assert.equal(implementations.inspectResult.failure.category, "unsupported_route");
+    assert.equal(Object.hasOwn(implementations.inspectResult, "implementations"), false);
   });
 });
 
@@ -199,6 +254,65 @@ async function withFixtureCopy(runFixture) {
   } finally {
     rmSync(temp, { recursive: true, force: true });
   }
+}
+
+async function withRustInspectFixture(runFixture) {
+  const temp = mkdtempSync(join(tmpdir(), "lattice-inspect-rust-"));
+  try {
+    writeRustFixture(temp);
+    await runFixture(temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function writeRustFixture(root) {
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src/lib.rs"),
+    [
+      "pub mod helpers;",
+      "pub mod consumer;",
+      "",
+      "pub trait Service {",
+      "    fn handle(&self) -> String;",
+      "}",
+      "",
+      "pub struct Widget;",
+      "",
+      "impl Widget {",
+      "    pub fn new() -> Self {",
+      "        Widget",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
+  writeFileSync(join(root, "src/helpers.rs"), "pub fn assist() -> String { \"ok\".to_string() }\n");
+  writeFileSync(
+    join(root, "src/consumer.rs"),
+    [
+      "use crate::helpers;",
+      "use crate::{Service, Widget};",
+      "",
+      "pub fn run() -> String {",
+      "    let widget = Widget::new();",
+      "    helpers::assist();",
+      "    widget.handle()",
+      "}",
+      "",
+      "#[cfg(test)]",
+      "mod tests {",
+      "    use super::*;",
+      "",
+      "    #[test]",
+      "    fn test_run() {",
+      "        assert_eq!(run(), \"ok\");",
+      "    }",
+      "}",
+      ""
+    ].join("\n")
+  );
 }
 
 function skipGeneratedStore(source) {


### PR DESCRIPTION
## Summary
- adds Rust coverage for graph query/search/impact/review-context/detect-changes through GraphProvider and CLI routes
- indexes extracted Rust signatures in graph FTS projection so Rust signature queries rank deterministically
- adds Rust inspect behavior: graph-backed references where graph facts suffice, degraded unsupported_route for Rust signature/implementation materialization without LS support

## Verification
- npm run build
- node --test tests/graph-query-conformance.test.mjs tests/graph-query-cli.test.mjs tests/graph-search-conformance.test.mjs tests/inspect-references.test.mjs
- node --test tests/inspect-signature.test.mjs tests/inspect-implementations.test.mjs
- npm run rust:check
- node scripts/check-workspace.mjs
- npm run pack:check
- node --test tests/contracts.test.mjs tests/schema-contracts.test.mjs
- git diff --check

Closes #27

Guardrails: no public release, npm publish, visibility change, announcement, registry/certification claim, or release artifact push.