### PR TITLE
feat: emit ASP provider command timing

### DIFF
--- a/packages/asp-provider/src/mapping.ts
+++ b/packages/asp-provider/src/mapping.ts
@@ -1,11 +1,13 @@
 import type {
+  CommandTiming,
+  CommandTimingPhase,
   GraphProviderMode,
   HypotheticalOverlay,
   ValidationDiagnostic,
   ValidationRequest,
   ValidationResult
 } from "@the-open-engine/opcore-contracts";
-import { validateRepoRelativePath } from "@the-open-engine/opcore-contracts";
+import { validateCommandTiming, validateRepoRelativePath } from "@the-open-engine/opcore-contracts";
 import type { JsonRpcPeer } from "./json-rpc.js";
 import { changesetDigest as computeChangesetDigest, diagnosticFingerprint, digestJson } from "./digests.js";
 import type {
@@ -37,6 +39,7 @@ import {
 const providerSource = OPCORE_PROVIDER_ID;
 const capabilityVersion = "check/0.1";
 const supportedComparison = "all";
+let firstAssessmentTiming = true;
 
 export function initializeResult(params: InitializeParams): JsonObject {
   if (params.protocolVersion !== ASP_PROTOCOL_VERSION) {
@@ -79,44 +82,50 @@ export async function evaluateChangeset(
   initialized: InitializedParams,
   rawParams: unknown
 ): Promise<Assessment> {
-  const started = Date.now();
+  const timing = createAssessmentTiming();
   const params = normalizeEvaluateParams(rawParams);
   const digest = params.changesetDigest ?? computeChangesetDigest(params.changeset);
   const selectedIds = normalizeRequestedChecks(params.checks);
   const selectedChecks = selectedValidationChecks(selectedIds);
   const changedPaths = changedScopePaths(params.changeset.changes);
-  const workspace = createAspHostValidationWorkspace(peer, initialize, initialized, params.changeset);
+  const workspace = timing.timeSync("host_workspace_binding", () =>
+    createAspHostValidationWorkspace(peer, initialize, initialized, params.changeset)
+  );
   let validationResult: ValidationResult;
   let request: ValidationRequest;
   const mappingDegradations = comparisonDegradations(params.comparison ?? "introduced");
 
   try {
-    const overlays = await overlaysForChanges(params.changeset.changes, workspace);
-    const graphMode = graphModeFor(params.callSite, selectedChecks);
-    request = {
-      requestId: digest,
-      repo: {
-        repoRoot: initialize.workspace?.root ?? process.cwd()
-      },
-      scope: {
-        kind: "files",
-        files: changedPaths
-      },
-      graph: {
-        mode: graphMode,
-        provider: "lattice-graph"
-      },
-      checks: selectedIds,
-      overlays
-    };
-    validationResult = await createAspProviderValidationRunner(workspace.workspace).runValidation(request);
+    request = await timing.timeAsync("changeset_overlay_mapping", async () => {
+      const overlays = await overlaysForChanges(params.changeset.changes, workspace);
+      const graphMode = graphModeFor(params.callSite, selectedChecks);
+      return {
+        requestId: digest,
+        repo: {
+          repoRoot: initialize.workspace?.root ?? process.cwd()
+        },
+        scope: {
+          kind: "files",
+          files: changedPaths
+        },
+        graph: {
+          mode: graphMode,
+          provider: "lattice-graph"
+        },
+        checks: selectedIds,
+        overlays
+      };
+    });
+    validationResult = await timing.timeAsync("validation", () =>
+      createAspProviderValidationRunner(workspace.workspace).runValidation(request)
+    );
   } catch (error) {
     const validationFailure = errorAssessment({
       baseline: params.changeset.baseline,
       changesetDigest: digest,
       changedPaths,
       selectedIds,
-      started,
+      timing: timing.finish(),
       readBlobIds: workspace.readBlobIds(),
       degradation: {
         source: providerSource,
@@ -137,7 +146,7 @@ export async function evaluateChangeset(
     requestedComparison: params.comparison ?? "introduced",
     mappingDegradations,
     readBlobIds: workspace.readBlobIds(),
-    started
+    timing: timing.finish(validationResult)
   });
   return stripForbiddenKeys(assessment) as Assessment;
 }
@@ -262,7 +271,7 @@ function assessmentFromValidationResult(args: {
   requestedComparison: string;
   mappingDegradations: readonly ProviderCoverageDegradation[];
   readBlobIds: readonly string[];
-  started: number;
+  timing: CommandTiming;
 }): Assessment {
   const resultDegradations = validationCoverageDegradations(args.validationResult);
   const degraded = uniqueDegradations([...args.mappingDegradations, ...resultDegradations.degraded]);
@@ -288,7 +297,7 @@ function assessmentFromValidationResult(args: {
       blobs: [...args.readBlobIds].sort()
     },
     provider: providerMetadata(),
-    timing: timing(args.started),
+    timing: args.timing,
     cache: {
       status: "disabled"
     }
@@ -300,7 +309,7 @@ function errorAssessment(args: {
   changesetDigest: string;
   changedPaths: readonly string[];
   selectedIds: readonly string[];
-  started: number;
+  timing: CommandTiming;
   readBlobIds: readonly string[];
   degradation: ProviderCoverageDegradation;
 }): Assessment {
@@ -331,7 +340,7 @@ function errorAssessment(args: {
       blobs: [...args.readBlobIds].sort()
     },
     provider: providerMetadata(),
-    timing: timing(args.started),
+    timing: args.timing,
     cache: {
       status: "disabled"
     }
@@ -502,17 +511,91 @@ function providerMetadata(): Assessment["provider"] {
   };
 }
 
-function timing(started: number): JsonObject {
-  const ended = Date.now();
+function diagnosticSource(_checkId: string): string {
+  return OPCORE_PROVIDER_ID;
+}
+
+type AssessmentTimingRecorder = {
+  timeSync<T>(phase: string, action: () => T): T;
+  timeAsync<T>(phase: string, action: () => Promise<T>): Promise<T>;
+  finish(validationResult?: ValidationResult): CommandTiming;
+};
+
+function createAssessmentTiming(): AssessmentTimingRecorder {
+  const startedAt = Date.now();
+  const processState = nextAssessmentProcessState();
+  const phases: CommandTimingPhase[] = [];
   return {
-    startedAt: new Date(started).toISOString(),
-    endedAt: new Date(ended).toISOString(),
-    elapsedMs: Math.max(0, ended - started)
+    timeSync<T>(phase: string, action: () => T): T {
+      const phaseStartedAt = Date.now();
+      try {
+        return action();
+      } finally {
+        phases.push({
+          phase,
+          durationMs: elapsedMs(phaseStartedAt)
+        });
+      }
+    },
+    async timeAsync<T>(phase: string, action: () => Promise<T>): Promise<T> {
+      const phaseStartedAt = Date.now();
+      try {
+        return await action();
+      } finally {
+        phases.push({
+          phase,
+          durationMs: elapsedMs(phaseStartedAt)
+        });
+      }
+    },
+    finish(validationResult) {
+      const durationMs = elapsedMs(startedAt);
+      return validateCommandTiming({
+        durationMs,
+        phases: [
+          ...phases,
+          ...validationCheckPhases(validationResult)
+        ],
+        processState
+      });
+    }
   };
 }
 
-function diagnosticSource(_checkId: string): string {
-  return OPCORE_PROVIDER_ID;
+function nextAssessmentProcessState(): CommandTiming["processState"] {
+  if (firstAssessmentTiming) {
+    firstAssessmentTiming = false;
+    return "cold";
+  }
+  return "warm";
+}
+
+function validationCheckPhases(result: ValidationResult | undefined): CommandTimingPhase[] {
+  return (result?.manifest?.runs ?? [])
+    .filter((run) => isNonNegativeFiniteNumber(run.durationMs))
+    .map((run) => ({
+      phase: `validation_${normalizePhaseId(run.checkId, "check")}`,
+      durationMs: run.durationMs as number
+    }));
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.max(0, Date.now() - startedAt);
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function normalizePhaseId(value: string, fallback: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[^a-z]+/, "")
+    .replace(/[_-]+$/g, "");
+  return /^[a-z][a-z0-9_-]*$/.test(normalized) ? normalized : fallback;
 }
 
 function uniqueDegradations(entries: readonly ProviderCoverageDegradation[]): ProviderCoverageDegradation[] {

--- a/packages/asp-provider/src/protocol.ts
+++ b/packages/asp-provider/src/protocol.ts
@@ -1,4 +1,4 @@
-import type { ValidationScopeKind } from "@the-open-engine/opcore-contracts";
+import type { CommandTiming, ValidationScopeKind } from "@the-open-engine/opcore-contracts";
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
@@ -105,7 +105,7 @@ export type Assessment = {
     artifactDigest?: string;
     capabilityFamily: string;
   };
-  timing: JsonObject;
+  timing: CommandTiming;
   cache: JsonObject;
 };
 

--- a/tests/asp-provider.test.mjs
+++ b/tests/asp-provider.test.mjs
@@ -44,12 +44,14 @@ describe("Opcore ASP provider", () => {
       writeFileSync(join(repo, "src/modify.ts"), "export const value = 1;\n");
       writeFileSync(join(repo, "src/delete.ts"), "export const deletedValue = 1;\n");
       writeFileSync(join(repo, "src/old-name.ts"), "export const renamedValue = 1;\n");
+      writeFileSync(join(repo, "src/lib.rs"), "pub fn answer() -> i32 { 42 }\n");
 
       const host = createHostWorkspace({
         "tsconfig.json": "{}\n",
         "src/modify.ts": "export const value = 1;\n",
         "src/delete.ts": "export const deletedValue = 1;\n",
-        "src/old-name.ts": "export const renamedValue = 1;\n"
+        "src/old-name.ts": "export const renamedValue = 1;\n",
+        "src/lib.rs": "pub fn answer() -> i32 { 42 }\n"
       });
       const peer = spawnProvider(host);
       try {
@@ -79,6 +81,7 @@ describe("Opcore ASP provider", () => {
 
         const changes = [
           host.modify("src/modify.ts", "export const value = ;\n"),
+          host.modify("src/lib.rs", "pub fn answer() -> i32 { 43 }\n"),
           host.create("src/create.ts", "export const createdValue = 1;\n"),
           host.delete("src/delete.ts"),
           host.rename("src/old-name.ts", "src/new-name.ts", "export const renamedValue = 2;\n")
@@ -91,7 +94,7 @@ describe("Opcore ASP provider", () => {
           changeset,
           changesetDigest,
           comparison: "introduced",
-          checks: ["typescript.syntax", "typescript.import-graph"]
+          checks: ["typescript.syntax", "typescript.import-graph", "rust.source-hygiene"]
         });
 
         assert.equal(assessment.provider.id, "opcore");
@@ -106,6 +109,15 @@ describe("Opcore ASP provider", () => {
         assert.ok(assessment.coverage.degraded.some((entry) => entry.reason === "unsupported" && /comparison/.test(entry.requirement)));
         assert.ok(assessment.coverage.degraded.some((entry) => entry.reason === "unavailable" && entry.requirement === "typescript.import-graph"));
         assert.equal(assessment.coverage.exhaustive, false);
+        assertCommandTiming(assessment.timing, {
+          expectedPhases: [
+            "changeset_overlay_mapping",
+            "host_workspace_binding",
+            "validation",
+            "validation_typescript_syntax",
+            "validation_rust_source-hygiene"
+          ]
+        });
         assertNoForbiddenKeys(assessment);
       } finally {
         peer.close();
@@ -444,6 +456,27 @@ function sha256File(path) {
 
 function assertKeys(value, expected) {
   assert.deepEqual(Object.keys(value).sort(), expected.sort());
+}
+
+function assertCommandTiming(timing, { expectedPhases }) {
+  assertKeys(timing, ["durationMs", "phases", "processState"]);
+  assert.equal(typeof timing.durationMs, "number");
+  assert.ok(timing.durationMs >= 0);
+  assert.match(timing.processState, /^(cold|warm)$/);
+  assert.equal(Array.isArray(timing.phases), true);
+  const phaseIds = new Set(timing.phases.map((phase) => phase.phase));
+  for (const expectedPhase of expectedPhases) {
+    assert.equal(phaseIds.has(expectedPhase), true, `missing timing phase ${expectedPhase}`);
+  }
+  for (const phase of timing.phases) {
+    assertKeys(phase, phase.fileCount === undefined ? ["durationMs", "phase"] : ["durationMs", "fileCount", "phase"]);
+    assert.match(phase.phase, /^[a-z][a-z0-9_-]*$/);
+    assert.equal(typeof phase.durationMs, "number");
+    assert.ok(phase.durationMs >= 0);
+  }
+  assert.equal(Object.hasOwn(timing, "startedAt"), false);
+  assert.equal(Object.hasOwn(timing, "endedAt"), false);
+  assert.equal(Object.hasOwn(timing, "elapsedMs"), false);
 }
 
 function canonicalJson(value) {


### PR DESCRIPTION
## Summary
- emit shared CommandTiming from ASP check/evaluate assessments
- measure host workspace binding, changeset overlay mapping, validation, and per-check validation phases
- assert ASP timing parity across TypeScript and Rust checks without legacy startedAt/endedAt/elapsedMs fields

## Verification
- node --test tests/asp-provider.test.mjs
- node --test tests/contracts.test.mjs tests/schema-contracts.test.mjs tests/opcore-timing.test.mjs tests/latency-budget-gate.test.mjs
- npm run build
- npm run lint
- npm run ci

Closes #33