### PR TITLE
chore(skills): add covibes/orchestra TS+Rust engineering skills (+ provenance carve-out)

### DIFF
--- a/.claude/skills/eslint/SKILL.md
+++ b/.claude/skills/eslint/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: eslint
+description: Create and enforce ESLint rules.
+---
+
+# ESLint Rule Engineering
+
+**MISSION: Turn every class of bug into a mechanical gate. Error messages ARE the documentation. ERRORS OVER WARNINGS. ALWAYS.**
+
+## BEFORE WRITING A NEW RULE
+
+**STOP. Check these FIRST:**
+
+| Check | WHY: consequence if skipped |
+|-------|----------------------------|
+| Can an EXISTING rule be GENERALIZED? Grep `eslint-local-rules/` | Duplicate rules = maintenance hell. 70+ exist. Duplication is a bug. |
+| Can a BUILT-IN rule handle it? (`no-restricted-imports`, `no-restricted-syntax`, `no-restricted-properties`) | Built-in rules are battle-tested. Custom rules need maintenance. |
+| Can the TYPE SYSTEM catch it? | Types > lint > docs. Compile-time is always better than lint-time. |
+| Is this a CLASS of bug or a one-off? | One-off = fix the code. Only classes deserve rules. |
+
+## RULE DESIGN PHILOSOPHY
+
+### Broad Over Narrow — ALWAYS
+
+```
+BAD:  "no-k8s-import-in-routes"     (too narrow — what about ec2? docker?)
+GOOD: "no-executor-implementation-coupling" (catches ALL concrete executor imports)
+
+BAD:  "no-db-client-in-tests"         (too narrow — what about services?)
+GOOD: "no-direct-db-client-construction" (catches ALL direct instantiation)
+
+BAD:  "no-docker-string-in-lifecycle" (too narrow — what about "k8s"? "ec2"?)
+GOOD: "no-environment-specific-code"  (catches ALL env-specific branching, configurable)
+```
+
+**The test:** Would adding a new provider/env/feature require a NEW rule? If yes, your rule is too narrow. GENERALIZE.
+
+### Configurable Over Hardcoded
+
+Rules MUST accept options for `allowedFiles`, `allowComment`, `forbiddenTerms` etc. so eslint.config.js can tune scope without touching rule code. See `no-environment-specific-code.js` as the gold standard.
+
+```javascript
+// GOOD: Configurable rule with schema
+schema: [{
+  type: "object",
+  properties: {
+    allowedFiles: { type: "array", items: { type: "string" } },
+    allowComment: { type: "string" },
+    forbiddenTerms: { type: "array", items: { type: "string" } },
+  },
+  additionalProperties: false,
+}],
+```
+
+### Error Messages — NON-NEGOTIABLE FORMAT
+
+Every error message MUST contain ALL THREE:
+
+1. **WHAT is forbidden** (the violation)
+2. **WHY it's forbidden** (the consequence — production incident, architectural violation, data loss)
+3. **HOW to fix it** (the exact alternative)
+
+```javascript
+// BAD: Useless message
+"Don't use process.env directly"
+
+// GOOD: Actionable, non-negotiable, explains consequence
+"FORBIDDEN: Direct process.env access. This bypasses runtime validation — " +
+"missing vars silently return undefined instead of failing at startup. " +
+"Fix: Use getEnv().VAR_NAME from config/env-validation.ts"
+```
+
+**Error messages are read by agents and juniors at 2am. They must be COMPLETE. No "see docs." No "consider using." TELL THEM EXACTLY WHAT TO DO.**
+
+## RULE IMPLEMENTATION PATTERN
+
+### File Structure
+
+```
+eslint-local-rules/
+  index.js                          # Registry — ALL rules exported here
+  path-match.js                     # Shared glob matcher (matchesAny)
+  my-new-rule.js                    # Rule implementation
+  my-new-rule.test.js               # REQUIRED: test with valid/invalid cases
+```
+
+### Rule Template
+
+**Gold standard reference:** Read `eslint-local-rules/no-environment-specific-code.js` — configurable, broad, actionable messages.
+
+| Required Element | Pattern |
+|-----------------|---------|
+| `meta.type` | ALWAYS `"problem"` (WHY: `"suggestion"` = ignored) |
+| `meta.messages` | `"FORBIDDEN: {{what}}. WHY: {{consequence}}. Fix: {{alternative}}."` |
+| `meta.schema` | Object with `allowedFiles`, `allowComment`, domain-specific options |
+| `create()` first line | `if (matchesAny(filename, allowedFiles)) return {};` (fast skip) |
+| `hasAllowComment()` | Check same-line/prev-line comment for escape hatch (logging ONLY) |
+| AST visitors | Specific node types (`CallExpression`, `Literal`, `MemberExpression`) — NOT `Program` walk |
+
+### Registration in index.js
+
+```javascript
+// In eslint-local-rules/index.js — add ONE line:
+"my-new-rule": require("./my-new-rule.js"),
+```
+
+### Configuration in eslint.config.js
+
+```javascript
+// In server/eslint.config.js — add to rules object:
+"local/my-new-rule": ["error", {
+  allowedFiles: ["**/implementations/**", "**/di/**"],
+  allowComment: "rule-ok",
+}],
+
+// For file-scoped rules, add override block:
+{
+  files: ["server/src/routes/**/*.ts"],
+  rules: {
+    "local/my-new-rule": ["error", { /* route-specific config */ }],
+  },
+},
+```
+
+## VERIFICATION — PROVE IT WORKS BEFORE COMMITTING
+
+### Step 1: Ad-hoc verify (OWNING LAYER)
+
+```bash
+# Test against a file that SHOULD trigger the rule
+npx eslint --no-eslintrc -c <(echo '
+import localRules from "./eslint-local-rules/index.js";
+export default [{ plugins: { local: localRules }, rules: { "local/my-rule": "error" }, files: ["**/*.ts"] }];
+') server/path/to/known-violation.ts
+
+# Test against a file that should NOT trigger
+npx eslint --rulesdir eslint-local-rules server/path/to/clean-file.ts
+```
+
+### Step 2: Write test cases
+
+```javascript
+// eslint-local-rules/my-new-rule.test.js
+const { RuleTester } = require("eslint");
+const rule = require("./my-new-rule.js");
+
+const tester = new RuleTester({ parserOptions: { ecmaVersion: 2022, sourceType: "module" } });
+
+tester.run("my-new-rule", rule, {
+  valid: [
+    // Cases that MUST pass — include edge cases and allowed patterns
+    { code: 'import { getEnv } from "./config/env-validation";', },
+    { code: 'process.env.NODE_ENV', options: [{ allowedFiles: ["**/test/**"] }],
+      filename: "test/foo.ts" },
+  ],
+  invalid: [
+    // Cases that MUST fail — test EVERY messageId
+    {
+      code: 'const x = process.env.MY_VAR;',
+      errors: [{ messageId: "forbidden" }],
+    },
+    // Test that allowComment suppresses
+    // Test that allowedFiles bypasses
+    // Test edge cases (destructuring, bracket access, etc.)
+  ],
+});
+```
+
+### Step 3: Run the test
+
+```bash
+node eslint-local-rules/my-new-rule.test.js
+```
+
+### Step 4: Full lint to catch existing violations
+
+```bash
+cd server && npx eslint --rule '{"local/my-new-rule": "error"}' 'src/**/*.ts' 'services/**/*.ts'
+```
+
+**If existing violations exist: FIX THEM ALL before committing the rule. The rule and the fixes ship together.**
+
+## ANTI-PATTERNS IN RULE DESIGN
+
+| Anti-Pattern | Why It's Wrong | Fix |
+|-------------|---------------|-----|
+| `type: "suggestion"` | Suggestions are IGNORED. This is enforcement. | ALWAYS `type: "problem"` |
+| Warning level | Warnings are noise. They train people to ignore lint. | ALWAYS `"error"` |
+| Message says "consider" or "should" | Passive language = optional = ignored | "FORBIDDEN" / "REJECTED" / "Fix:" |
+| No `allowedFiles` option | Rule can't be scoped = disabled entirely when one file needs exception | Add schema with `allowedFiles` |
+| Hardcoded file paths in rule | Paths change, rule breaks silently | Use `allowedFiles` in config |
+| No test file | Untested rule = broken rule waiting to happen | ALWAYS ship `.test.js` |
+| Catches one specific term | Too narrow — won't catch the next variant | Generalize to the CLASS |
+| No WHY in error message | Developer doesn't understand, works around instead of fixing | Include consequence + postmortem reference |
+
+## SUPPRESSION COMMENT CONVENTIONS
+
+When `allowedFiles` scoping is too broad but code is correct and the rule is a false positive, use inline suppression comments. NEVER suppress just to make lint pass — suppression is for genuine false positives only.
+
+| Comment | Rule(s) | When Legitimate |
+|---------|---------|----------------|
+| `// env-ok: <reason>` | `ban-process-env`, `require-validated-env-vars`, `no-process-env-in-socket` | CLI check scripts in `checks/` that are standalone executables, not server application code. They need raw `process.env` before validation infrastructure is loaded. |
+| `// port-ok: <reason>` | `no-hardcoded-ports` | Test fixtures, constants files, or protocol definitions where the port IS the contract. |
+| `// promise-ok: <reason>` | `no-unbounded-promise-all-map` | Bounded arrays where cardinality is provably small (e.g. `worktrees.map` max 10). |
+
+**`checks/` directory pattern:** NamedCheck extension files are CLI scripts that run as standalone executables. `ban-process-env` flags them because they use `process.env` directly — this is correct for CLI scripts that run before server validation infrastructure loads. Use `// env-ok: CLI check script, not server application code` on the specific line.
+
+## EXISTING RULE INVENTORY (Check Before Creating)
+
+| Category | Rules | Generalizable? |
+|----------|-------|----------------|
+| **Env/infra boundary** | `no-environment-specific-code`, `ban-process-env`, `no-runtime-mode-env-checks`, `no-self-hosted-checks`, `require-validated-env-vars`, `no-forbidden-abstraction-terms` | Extend `no-forbidden-abstraction-terms` for new leaked terms |
+| **DI/factory boundary** | `no-direct-service-instantiation`, `no-module-scope-instantiation`, `no-di-circular-call`, `no-direct-factory-bypass`, `no-service-locator-defaults`, `no-exported-service-singleton` | Extend `no-direct-service-instantiation` allowedFiles |
+| **Executor boundary** | `no-executor-implementation-coupling`, `no-detect-worker-type`, `no-executor-capability-flags`, `no-executor-env-introspection` | These are comprehensive — rarely need new ones |
+| **Provider boundary** | `no-provider-name-check`, `no-provider-implementation-leak`, `no-direct-guardrail-branching` | Extend `no-provider-implementation-leak` for new providers |
+| **DB/ORM** | `no-direct-db-client-construction`, `require-deterministic-query-order`, `require-integrity-gates-for-multi-step-reads`, `require-transaction-for-multi-write` | Prefer broad invariants over entity-specific rules |
+| **API contract** | `require-typed-response`, `require-contract-registration`, `no-inline-api-body` | Extend for new route patterns |
+| **Socket/transport** | `require-validated-socket-emit`, `ban-direct-emit-validated`, `no-unknown-socket-emit-data` | Well-covered |
+| **Security** | `no-adhoc-commands`, `no-dangerous-spawn`, `no-dangerous-fallbacks`, `no-metadata-spread`, `require-boundary-validation` | Extend for new injection vectors |
+| **Code structure** | `no-runtime-logic-in-types-modules`, `registration-module-delegation-only`, `no-multi-subcommand-workflows`, `no-legacy-labeling` | Extend for new SRP violations |
+| **Client** | `no-hardcoded-colors`, `no-unpaired-theme-class`, `react-no-unstable-hook-deps`, `react-no-derived-state-from-props`, `no-direct-auth-token-storage`, `no-empty-token-setter`, `no-direct-local-storage`, `require-auth-transition-reset` | Well-covered |
+| **Testing** | `require-dual-module-mock` | Extend for new mock patterns |
+| **Robustness** | `require-error-context`, `no-empty-catch`, `no-hardcoded-ports`, `no-unsafe-type-assertion`, `no-dynamic-import-concat`, `no-static-optional-import`, `no-raw-network-without-timeout`, `no-unbounded-promise-all-map`, `zod-record-two-args` | Keep them in a shared robustness lint pack when multiple repos need them |
+
+## SHARED UTILITIES
+
+| File | Exports | Use For |
+|------|---------|---------|
+| `path-match.js` | `matchesAny(filename, globs)` | File path allowlisting in ALL rules |
+
+## PERFORMANCE
+
+- Rules run on EVERY file during lint. Keep visitors minimal.
+- Use `matchesAny()` early return for `allowedFiles` (skip entire file).
+- Avoid `Program` visitor + walking full AST — use specific node visitors.
+- Avoid regex in hot paths — use `Set.has()` for term matching.
+
+## WORKFLOW SUMMARY
+
+1. **Bug found** → Is this a CLASS of bug?
+2. **Check existing rules** → Can one be EXTENDED?
+3. **If new rule needed** → Generalize to the broadest CLASS
+4. **Write rule** → `type: "problem"`, configurable schema, ACTIONABLE error messages
+5. **Write test** → Valid AND invalid cases, all messageIds covered
+6. **Ad-hoc verify** → Run against known violations AND clean files
+7. **Fix ALL existing violations** → Rule + fixes ship together
+8. **Register** → `index.js` + `eslint.config.js`
+9. **Commit** → Pre-commit runs full lint to verify

--- a/.claude/skills/repo-tooling/SKILL.md
+++ b/.claude/skills/repo-tooling/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: repo-tooling
+description: Use repo-provided crg, cix, and rox, and follow the language and quality skills before writing code.
+---
+
+# Repo Tooling
+
+- Prefer repo-provided `crg` for indexed code search and impact analysis before broad scans.
+- Use repo-provided `cix` when you need repo-aware code intelligence or refactors instead of ad hoc grep and manual edits.
+- For cohesive large deltas prepared in a patch file or temporary tree, run `cix apply-patch --patch <file> --check --json` or `cix apply-tree --from <dir> --check --json` before applying.
+- Apply the same `cix apply-patch` / `cix apply-tree` command without `--check` only after reviewing the reported file set. Do not pass `--skip-validation` unless debugging `cix` itself.
+- Prefer structured `cix` operations (`rename`, `move`, `change-signature`, `multi-edit`, `search-replace`) when they fit; use `apply-patch` / `apply-tree` for whole-delta import.
+- Use repo-provided `rox` for repository-owned validation and staged checks when the workspace exposes it.
+- If Rox hypothetical validation is unavailable, say so and run scoped `rox check --files` after applying.
+- If these tools are absent, fail open and use the next best local fallback instead of assuming the repo supports them.
+- Treat repo-local wrappers or bootstrap scripts as compatibility or product-specific glue, not as the generic ACE contract. Generic tool/runtime/worktree behavior belongs to the packaged ACE command surface and should not be re-explained as prompt content.
+
+## Language and quality skills (read before writing code)
+
+This repo holds TypeScript/JavaScript and Rust. Match the engineering standard used in the covibes and orchestra repos: before writing or reviewing code, read the matching skill and follow it.
+
+- **TypeScript / JavaScript** -> `.claude/skills/typescript/SKILL.md` - strict typing, no `any`, discriminated unions over loose booleans, exhaustive `switch`, narrow module boundaries, real error handling.
+- **TypeScript / JS linting** -> `.claude/skills/eslint/SKILL.md` - keep code lint-clean; never blanket-disable rules to pass.
+- **Rust** -> `.claude/skills/rust-engineer/SKILL.md` plus its `references/` (ownership, traits, error-handling, performance, documentation). For async or concurrency also read `.claude/skills/rust-async-patterns/SKILL.md`.
+- **Tests (any language)** -> `.claude/skills/testing/SKILL.md` - behaviour-focused tests with real assertions; no trivial or always-true tests.
+
+Do not weaken existing guardrails - Rox, clippy `-D warnings`, `cargo fmt --check`, `tsc`, and (where present) ESLint - to make code pass. Fix the code instead.

--- a/.claude/skills/rust-async-patterns/SKILL.md
+++ b/.claude/skills/rust-async-patterns/SKILL.md
@@ -1,0 +1,490 @@
+---
+name: rust-async-patterns
+description: Master Rust async programming with Tokio, async traits, error handling, and concurrent patterns. Use when building async Rust applications, implementing concurrent systems, or debugging async code.
+---
+
+# Rust Async Patterns
+
+Production patterns for async Rust programming with Tokio runtime, including tasks, channels, streams, and error handling.
+
+## When to Use This Skill
+
+- Building async Rust applications
+- Implementing concurrent network services
+- Using Tokio for async I/O
+- Handling async errors properly
+- Debugging async code issues
+- Optimizing async performance
+
+## Core Concepts
+
+### 1. Async Execution Model
+
+```
+Future (lazy) -> poll() -> Ready(value) | Pending
+                ^           |
+              Waker <- Runtime schedules
+```
+
+### 2. Key Abstractions
+
+| Concept    | Purpose                                  |
+| ---------- | ---------------------------------------- |
+| `Future`   | Lazy computation that may complete later |
+| `async fn` | Function returning impl Future           |
+| `await`    | Suspend until future completes           |
+| `Task`     | Spawned future running concurrently      |
+| `Runtime`  | Executor that polls futures              |
+
+## Quick Start
+
+```toml
+# Cargo.toml
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+async-trait = "0.1"
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+```
+
+```rust
+use tokio::time::{sleep, Duration};
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt::init();
+
+    // Async operations
+    let result = fetch_data("https://api.example.com").await?;
+    println!("Got: {}", result);
+
+    Ok(())
+}
+
+async fn fetch_data(url: &str) -> Result<String> {
+    // Simulated async operation
+    sleep(Duration::from_millis(100)).await;
+    Ok(format!("Data from {}", url))
+}
+```
+
+## Patterns
+
+### Pattern 1: Concurrent Task Execution
+
+```rust
+use tokio::task::JoinSet;
+use anyhow::Result;
+
+// Spawn multiple concurrent tasks
+async fn fetch_all_concurrent(urls: Vec<String>) -> Result<Vec<String>> {
+    let mut set = JoinSet::new();
+
+    for url in urls {
+        set.spawn(async move {
+            fetch_data(&url).await
+        });
+    }
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        match res {
+            Ok(Ok(data)) => results.push(data),
+            Ok(Err(e)) => tracing::error!("Task failed: {}", e),
+            Err(e) => tracing::error!("Join error: {}", e),
+        }
+    }
+
+    Ok(results)
+}
+
+// With concurrency limit
+use futures::stream::{self, StreamExt};
+
+async fn fetch_with_limit(urls: Vec<String>, limit: usize) -> Vec<Result<String>> {
+    stream::iter(urls)
+        .map(|url| async move { fetch_data(&url).await })
+        .buffer_unordered(limit)
+        .collect()
+        .await
+}
+
+// Select first to complete
+use tokio::select;
+
+async fn race_requests(url1: &str, url2: &str) -> Result<String> {
+    select! {
+        result = fetch_data(url1) => result,
+        result = fetch_data(url2) => result,
+    }
+}
+```
+
+### Pattern 2: Channels for Communication
+
+```rust
+use tokio::sync::{mpsc, broadcast, oneshot, watch};
+
+// Multi-producer, single-consumer
+async fn mpsc_example() {
+    let (tx, mut rx) = mpsc::channel::<String>(100);
+
+    // Spawn producer
+    let tx2 = tx.clone();
+    tokio::spawn(async move {
+        tx2.send("Hello".to_string()).await.unwrap();
+    });
+
+    // Consume
+    while let Some(msg) = rx.recv().await {
+        println!("Got: {}", msg);
+    }
+}
+
+// Broadcast: multi-producer, multi-consumer
+async fn broadcast_example() {
+    let (tx, _) = broadcast::channel::<String>(100);
+
+    let mut rx1 = tx.subscribe();
+    let mut rx2 = tx.subscribe();
+
+    tx.send("Event".to_string()).unwrap();
+
+    let _ = rx1.recv().await;
+    let _ = rx2.recv().await;
+}
+
+// Oneshot: single value, single use
+async fn oneshot_example() -> String {
+    let (tx, rx) = oneshot::channel::<String>();
+
+    tokio::spawn(async move {
+        tx.send("Result".to_string()).unwrap();
+    });
+
+    rx.await.unwrap()
+}
+
+// Watch: single producer, multi-consumer, latest value
+async fn watch_example() {
+    let (tx, mut rx) = watch::channel("initial".to_string());
+
+    tokio::spawn(async move {
+        loop {
+            rx.changed().await.unwrap();
+            println!("New value: {}", *rx.borrow());
+        }
+    });
+
+    tx.send("updated".to_string()).unwrap();
+}
+```
+
+### Pattern 3: Async Error Handling
+
+```rust
+use anyhow::{Context, Result, bail};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ServiceError {
+    #[error("Network error: {0}")]
+    Network(#[from] reqwest::Error),
+
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("Timeout after {0:?}")]
+    Timeout(std::time::Duration),
+}
+
+async fn process_request(id: &str) -> Result<Response> {
+    let data = fetch_data(id)
+        .await
+        .context("Failed to fetch data")?;
+
+    let parsed = parse_response(&data)
+        .context("Failed to parse response")?;
+
+    Ok(parsed)
+}
+
+async fn get_user(id: &str) -> Result<User, ServiceError> {
+    let result = db.query(id).await?;
+
+    match result {
+        Some(user) => Ok(user),
+        None => Err(ServiceError::NotFound(id.to_string())),
+    }
+}
+
+use tokio::time::timeout;
+
+async fn with_timeout<T, F>(duration: Duration, future: F) -> Result<T, ServiceError>
+where
+    F: std::future::Future<Output = Result<T, ServiceError>>,
+{
+    timeout(duration, future)
+        .await
+        .map_err(|_| ServiceError::Timeout(duration))?
+}
+```
+
+### Pattern 4: Graceful Shutdown
+
+```rust
+use tokio::signal;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+async fn run_server() -> Result<()> {
+    let token = CancellationToken::new();
+    let token_clone = token.clone();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = token_clone.cancelled() => {
+                    tracing::info!("Task shutting down");
+                    break;
+                }
+                _ = do_work() => {}
+            }
+        }
+    });
+
+    signal::ctrl_c().await?;
+    tracing::info!("Shutdown signal received");
+
+    token.cancel();
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    Ok(())
+}
+
+async fn run_with_broadcast() -> Result<()> {
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
+
+    let mut rx = shutdown_tx.subscribe();
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = rx.recv() => {
+                tracing::info!("Received shutdown");
+            }
+            _ = async { loop { do_work().await } } => {}
+        }
+    });
+
+    signal::ctrl_c().await?;
+    let _ = shutdown_tx.send(());
+
+    Ok(())
+}
+```
+
+### Pattern 5: Async Traits
+
+```rust
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Repository {
+    async fn get(&self, id: &str) -> Result<Entity>;
+    async fn save(&self, entity: &Entity) -> Result<()>;
+    async fn delete(&self, id: &str) -> Result<()>;
+}
+
+pub struct PostgresRepository {
+    pool: sqlx::PgPool,
+}
+
+#[async_trait]
+impl Repository for PostgresRepository {
+    async fn get(&self, id: &str) -> Result<Entity> {
+        sqlx::query_as!(Entity, "SELECT * FROM entities WHERE id = $1", id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn save(&self, entity: &Entity) -> Result<()> {
+        sqlx::query!(
+            "INSERT INTO entities (id, data) VALUES ($1, $2)
+             ON CONFLICT (id) DO UPDATE SET data = $2",
+            entity.id,
+            entity.data
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn delete(&self, id: &str) -> Result<()> {
+        sqlx::query!("DELETE FROM entities WHERE id = $1", id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+async fn process(repo: &dyn Repository, id: &str) -> Result<()> {
+    let entity = repo.get(id).await?;
+    repo.save(&entity).await
+}
+```
+
+### Pattern 6: Streams and Async Iteration
+
+```rust
+use futures::stream::{self, Stream, StreamExt};
+use async_stream::stream;
+
+fn numbers_stream() -> impl Stream<Item = i32> {
+    stream! {
+        for i in 0..10 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            yield i;
+        }
+    }
+}
+
+async fn process_stream() {
+    let stream = numbers_stream();
+
+    let processed: Vec<_> = stream
+        .filter(|n| futures::future::ready(*n % 2 == 0))
+        .map(|n| n * 2)
+        .collect()
+        .await;
+
+    println!("{:?}", processed);
+}
+
+async fn process_in_chunks() {
+    let stream = numbers_stream();
+
+    let mut chunks = stream.chunks(3);
+
+    while let Some(chunk) = chunks.next().await {
+        println!("Processing chunk: {:?}", chunk);
+    }
+}
+
+async fn merge_streams() {
+    let stream1 = numbers_stream();
+    let stream2 = numbers_stream();
+
+    let merged = stream::select(stream1, stream2);
+
+    merged
+        .for_each(|n| async move {
+            println!("Got: {}", n);
+        })
+        .await;
+}
+```
+
+### Pattern 7: Resource Management
+
+```rust
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock, Semaphore};
+
+struct Cache {
+    data: RwLock<HashMap<String, String>>,
+}
+
+impl Cache {
+    async fn get(&self, key: &str) -> Option<String> {
+        self.data.read().await.get(key).cloned()
+    }
+
+    async fn set(&self, key: String, value: String) {
+        self.data.write().await.insert(key, value);
+    }
+}
+
+struct Pool {
+    semaphore: Semaphore,
+    connections: Mutex<Vec<Connection>>,
+}
+
+impl Pool {
+    fn new(size: usize) -> Self {
+        Self {
+            semaphore: Semaphore::new(size),
+            connections: Mutex::new((0..size).map(|_| Connection::new()).collect()),
+        }
+    }
+
+    async fn acquire(&self) -> PooledConnection<'_> {
+        let permit = self.semaphore.acquire().await.unwrap();
+        let conn = self.connections.lock().await.pop().unwrap();
+        PooledConnection { pool: self, conn: Some(conn), _permit: permit }
+    }
+}
+
+struct PooledConnection<'a> {
+    pool: &'a Pool,
+    conn: Option<Connection>,
+    _permit: tokio::sync::SemaphorePermit<'a>,
+}
+
+impl Drop for PooledConnection<'_> {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            let pool = self.pool;
+            tokio::spawn(async move {
+                pool.connections.lock().await.push(conn);
+            });
+        }
+    }
+}
+```
+
+## Debugging Tips
+
+```rust
+// Enable tokio-console for runtime debugging
+// Cargo.toml: tokio = { features = ["tracing"] }
+// Run: RUSTFLAGS="--cfg tokio_unstable" cargo run
+// Then: tokio-console
+
+use tracing::instrument;
+
+#[instrument(skip(pool))]
+async fn fetch_user(pool: &PgPool, id: &str) -> Result<User> {
+    tracing::debug!("Fetching user");
+    // ...
+}
+
+let span = tracing::info_span!("worker", id = %worker_id);
+tokio::spawn(async move {
+    // Enters span when polled
+}.instrument(span));
+```
+
+## Best Practices
+
+### Do's
+
+- **Use `tokio::select!`** - For racing futures
+- **Prefer channels** - Over shared state when possible
+- **Use `JoinSet`** - For managing multiple tasks
+- **Instrument with tracing** - For debugging async code
+- **Handle cancellation** - Check `CancellationToken`
+
+### Don'ts
+
+- **Don't block** - Never use `std::thread::sleep` in async
+- **Don't hold locks across awaits** - Causes deadlocks
+- **Don't spawn unboundedly** - Use semaphores for limits
+- **Don't ignore errors** - Propagate with `?` or log
+- **Don't forget Send bounds** - For spawned futures

--- a/.claude/skills/rust-engineer/SKILL.md
+++ b/.claude/skills/rust-engineer/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: rust-engineer
+description: Canonical Rust implementation skill for writing, reviewing, refactoring, and debugging idiomatic Rust. Use when building Rust crates or binaries, shaping APIs around ownership and traits, implementing Tokio async code, choosing error handling, tightening tests/lints/docs, or optimizing for correctness and performance.
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.2.0"
+  domain: language
+  triggers: Rust, Cargo, ownership, borrowing, lifetimes, async Rust, tokio, zero-cost abstractions, memory safety, systems programming
+  role: specialist
+  scope: implementation
+  output-format: code
+  related-skills: test-master
+---
+
+# Rust Engineer
+
+Primary Rust skill for agentic coding. Keep this file lean; load only the references needed for the task instead of reading the whole skill tree.
+
+## Use This Skill For
+
+- New Rust implementation work
+- Refactors that affect ownership, traits, or async boundaries
+- Debugging borrow checker, lifetime, Send/Sync, or error-handling issues
+- Code review of Rust correctness, API shape, and performance risks
+- Tightening tests, lint discipline, or public API documentation
+
+## Core Workflow
+
+1. **Shape the API first** — Choose borrowed vs owned inputs, error types, trait boundaries, and sync vs async semantics before writing bodies.
+2. **Load only relevant references** — Pull in ownership, traits, async, testing, linting, performance, or docs guidance as needed.
+3. **Implement idiomatically** — Prefer borrowing over cloning, static dispatch over dynamic dispatch unless heterogeneity is required, and explicit invariants over comments that restate code.
+4. **Make failure legible** — Use `Result`/`Option`, typed library errors with `thiserror`, and `anyhow` only at application boundaries.
+5. **Prove behavior at the right layer** — Unit test function logic, integration test crate boundaries, doctest public APIs, and benchmark only after a measurable concern exists.
+6. **Finish with the mechanical pass** — Run formatting, clippy, and tests; either fix warnings or justify the narrow exception inline.
+
+## Default Load Order
+
+Start with the smallest relevant set:
+
+- `references/ownership.md` for API shape, borrowing, lifetimes, smart pointers, and `Send`/`Sync`
+- `references/error-handling.md` for `Result`, `Option`, `thiserror`, `anyhow`, and context
+- `references/testing.md` for unit/integration/doctest/property/snapshot strategy
+
+Add these only when needed:
+
+- `references/traits.md` for trait design, bounds, associated types, dispatch, and conversion traits
+- `references/async.md` for Tokio, concurrency, cancellation, channels, streams, and async pitfalls
+- `references/linting.md` for clippy discipline and suppression rules
+- `references/performance.md` for measuring first, clone pressure, allocation shape, and dispatch costs
+- `references/documentation.md` for doc comments, `SAFETY:` comments, and maintainer-facing rationale
+
+## Quick Rules
+
+- Prefer `&str`, `&Path`, `&[T]`, and `&T` for read-only inputs. Accept owned values only when the function must store, transform, or transfer ownership.
+- Avoid `&String` and `&Vec<T>` in public APIs unless the function truly depends on those concrete container types.
+- Prefer `thiserror` for library or reusable crate errors; use `anyhow` at binaries, CLI entrypoints, and orchestration layers.
+- Avoid `unwrap()` and `expect()` in production paths. Use them in tests or when failure is genuinely impossible and the invariant is documented.
+- Use generics and static dispatch by default; use `dyn Trait` at deliberate runtime boundaries or for heterogeneous collections.
+- Prefer explicit types and invariants over comments. Comments should explain **why**, not restate **what**.
+- Optimize only after measurement. Redundant cloning, needless allocation, and accidental dynamic dispatch are common real problems; speculative micro-optimizations are not.
+
+## Validation Commands
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --all-features --locked
+cargo test --doc --locked
+```
+
+Use narrower commands when the workspace or task requires it, but treat these as the default finish line.
+
+## Output Expectations
+
+When implementing or reviewing Rust code, prefer answers that include:
+
+1. API shape decisions: borrowing, ownership, trait bounds, and error type choices
+2. Implementation that is idiomatic and explicit about invariants
+3. Tests or verification at the owning layer
+4. Short notes on tradeoffs only where they matter
+
+## Knowledge Reference
+
+Rust 2021+, Cargo, ownership/borrowing, lifetimes, traits, generics, async/await, tokio, `Result`/`Option`, `thiserror`/`anyhow`, clippy, rustfmt, doctests, property testing, criterion, Miri, unsafe Rust

--- a/.claude/skills/rust-engineer/references/async.md
+++ b/.claude/skills/rust-engineer/references/async.md
@@ -1,0 +1,458 @@
+# Async Programming in Rust
+
+## Basic Async/Await
+
+```rust
+use tokio;
+
+// Async function returns a Future
+async fn fetch_data(url: &str) -> Result<String, reqwest::Error> {
+    let response = reqwest::get(url).await?;
+    let body = response.text().await?;
+    Ok(body)
+}
+
+// Tokio runtime
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let data = fetch_data("https://api.example.com").await?;
+    println!("Data: {}", data);
+    Ok(())
+}
+
+// Manual runtime creation
+fn main() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        println!("Hello from async context");
+    });
+}
+```
+
+## Concurrent Execution
+
+```rust
+use tokio;
+
+// Sequential execution
+async fn sequential() {
+    let result1 = async_operation1().await;
+    let result2 = async_operation2().await;  // Waits for operation1
+}
+
+// Concurrent execution with join!
+async fn concurrent() {
+    let (result1, result2) = tokio::join!(
+        async_operation1(),
+        async_operation2()
+    );
+}
+
+// Concurrent with try_join! (stops on first error)
+async fn concurrent_with_errors() -> Result<(), Box<dyn std::error::Error>> {
+    let (result1, result2) = tokio::try_join!(
+        fallible_operation1(),
+        fallible_operation2()
+    )?;
+    Ok(())
+}
+
+// Spawning tasks
+async fn spawn_tasks() {
+    let handle1 = tokio::spawn(async {
+        // This runs on a separate task
+        expensive_computation().await
+    });
+
+    let handle2 = tokio::spawn(async {
+        another_computation().await
+    });
+
+    // Wait for both to complete
+    let result1 = handle1.await.unwrap();
+    let result2 = handle2.await.unwrap();
+}
+```
+
+## Select and Race Conditions
+
+```rust
+use tokio::time::{sleep, Duration};
+
+// select! - wait for first to complete
+async fn first_to_complete() {
+    tokio::select! {
+        result = async_operation1() => {
+            println!("Operation 1 completed first: {:?}", result);
+        }
+        result = async_operation2() => {
+            println!("Operation 2 completed first: {:?}", result);
+        }
+    }
+}
+
+// Timeout pattern
+async fn with_timeout() -> Result<String, &'static str> {
+    tokio::select! {
+        result = fetch_data("https://api.example.com") => {
+            result.map_err(|_| "Fetch failed")
+        }
+        _ = sleep(Duration::from_secs(5)) => {
+            Err("Timeout")
+        }
+    }
+}
+
+// Cancellation with select!
+async fn cancellable_operation(mut cancel_rx: tokio::sync::watch::Receiver<bool>) {
+    tokio::select! {
+        result = long_running_task() => {
+            println!("Task completed: {:?}", result);
+        }
+        _ = cancel_rx.changed() => {
+            println!("Task cancelled");
+        }
+    }
+}
+```
+
+## Streams
+
+```rust
+use tokio_stream::{self as stream, StreamExt};
+
+// Creating streams
+async fn stream_example() {
+    let mut stream = stream::iter(vec![1, 2, 3, 4, 5]);
+
+    while let Some(value) = stream.next().await {
+        println!("Value: {}", value);
+    }
+}
+
+// Stream combinators
+async fn stream_combinators() {
+    let stream = stream::iter(vec![1, 2, 3, 4, 5])
+        .filter(|x| *x % 2 == 0)
+        .map(|x| x * 2);
+
+    let results: Vec<_> = stream.collect().await;
+    println!("Results: {:?}", results);
+}
+
+// Async stream processing
+use futures::stream::{self, StreamExt};
+
+async fn process_stream() {
+    let stream = stream::iter(vec![1, 2, 3, 4, 5])
+        .then(|x| async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            x * 2
+        });
+
+    stream.for_each(|x| async move {
+        println!("Processed: {}", x);
+    }).await;
+}
+```
+
+## Channels for Communication
+
+```rust
+use tokio::sync::{mpsc, oneshot, broadcast, watch};
+
+// mpsc: multiple producer, single consumer
+async fn mpsc_example() {
+    let (tx, mut rx) = mpsc::channel(32);
+
+    tokio::spawn(async move {
+        tx.send("Hello").await.unwrap();
+        tx.send("World").await.unwrap();
+    });
+
+    while let Some(msg) = rx.recv().await {
+        println!("Received: {}", msg);
+    }
+}
+
+// oneshot: single value, one-time use
+async fn oneshot_example() {
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        tx.send("Result").unwrap();
+    });
+
+    let result = rx.await.unwrap();
+    println!("Got: {}", result);
+}
+
+// broadcast: multiple producers, multiple consumers
+async fn broadcast_example() {
+    let (tx, mut rx1) = broadcast::channel(16);
+    let mut rx2 = tx.subscribe();
+
+    tokio::spawn(async move {
+        tx.send("Message").unwrap();
+    });
+
+    println!("rx1: {}", rx1.recv().await.unwrap());
+    println!("rx2: {}", rx2.recv().await.unwrap());
+}
+
+// watch: single producer, multiple consumers (last value)
+async fn watch_example() {
+    let (tx, mut rx) = watch::channel("initial");
+
+    tokio::spawn(async move {
+        loop {
+            rx.changed().await.unwrap();
+            println!("Value changed to: {}", *rx.borrow());
+        }
+    });
+
+    tx.send("updated").unwrap();
+}
+```
+
+## Shared State
+
+```rust
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+// Mutex for exclusive access
+async fn mutex_example() {
+    let data = Arc::new(Mutex::new(0));
+
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let data = Arc::clone(&data);
+        let handle = tokio::spawn(async move {
+            let mut lock = data.lock().await;
+            *lock += 1;
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    println!("Final value: {}", *data.lock().await);
+}
+
+// RwLock for read-write patterns
+async fn rwlock_example() {
+    let data = Arc::new(RwLock::new(vec![1, 2, 3]));
+
+    // Multiple readers
+    let data1 = Arc::clone(&data);
+    tokio::spawn(async move {
+        let read = data1.read().await;
+        println!("Read: {:?}", *read);
+    });
+
+    let data2 = Arc::clone(&data);
+    tokio::spawn(async move {
+        let read = data2.read().await;
+        println!("Read: {:?}", *read);
+    });
+
+    // Single writer
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let mut write = data.write().await;
+    write.push(4);
+}
+```
+
+## Async Traits (with async-trait)
+
+```rust
+use async_trait::async_trait;
+
+#[async_trait]
+trait AsyncRepository {
+    async fn find_by_id(&self, id: u64) -> Result<User, Error>;
+    async fn save(&self, user: User) -> Result<(), Error>;
+}
+
+struct DatabaseRepository {
+    pool: sqlx::PgPool,
+}
+
+#[async_trait]
+impl AsyncRepository for DatabaseRepository {
+    async fn find_by_id(&self, id: u64) -> Result<User, Error> {
+        sqlx::query_as("SELECT * FROM users WHERE id = $1")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn save(&self, user: User) -> Result<(), Error> {
+        sqlx::query("INSERT INTO users (name, email) VALUES ($1, $2)")
+            .bind(&user.name)
+            .bind(&user.email)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+```
+
+## Pin and Futures
+
+```rust
+use std::pin::Pin;
+use std::future::Future;
+use std::task::{Context, Poll};
+
+// Manual Future implementation
+struct DelayedValue {
+    value: i32,
+    delay: tokio::time::Sleep,
+}
+
+impl Future for DelayedValue {
+    type Output = i32;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.delay).poll(cx) {
+            Poll::Ready(_) => Poll::Ready(self.value),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+// Using pinned futures
+async fn use_pinned() {
+    let future = DelayedValue {
+        value: 42,
+        delay: tokio::time::sleep(Duration::from_secs(1)),
+    };
+
+    let result = future.await;
+    println!("Result: {}", result);
+}
+```
+
+## Background Tasks and Graceful Shutdown
+
+```rust
+use tokio::signal;
+
+async fn background_task(mut shutdown: tokio::sync::watch::Receiver<bool>) {
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(1)) => {
+                println!("Background task running...");
+            }
+            _ = shutdown.changed() => {
+                println!("Shutting down background task");
+                break;
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    let task = tokio::spawn(background_task(shutdown_rx));
+
+    // Wait for ctrl-c
+    signal::ctrl_c().await.unwrap();
+    println!("Received shutdown signal");
+
+    // Signal shutdown
+    shutdown_tx.send(true).unwrap();
+
+    // Wait for task to complete
+    task.await.unwrap();
+}
+```
+
+## Error Handling in Async
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum AsyncError {
+    #[error("Network error: {0}")]
+    Network(#[from] reqwest::Error),
+
+    #[error("Timeout")]
+    Timeout,
+
+    #[error("Task failed")]
+    TaskFailed(#[from] tokio::task::JoinError),
+}
+
+async fn robust_operation() -> Result<String, AsyncError> {
+    let timeout = Duration::from_secs(5);
+
+    let result = tokio::time::timeout(timeout, async {
+        reqwest::get("https://api.example.com")
+            .await?
+            .text()
+            .await
+    })
+    .await
+    .map_err(|_| AsyncError::Timeout)??;
+
+    Ok(result)
+}
+```
+
+## Runtime Configuration
+
+```rust
+// Custom runtime configuration
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_name("my-worker")
+        .thread_stack_size(3 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        println!("Running on custom runtime");
+    });
+}
+
+// Current-thread runtime (single-threaded)
+fn single_threaded() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        println!("Single-threaded async");
+    });
+}
+```
+
+## Best Practices
+
+- Use tokio::spawn for CPU-bound tasks on multi-threaded runtime
+- Use spawn_blocking for blocking operations (file I/O, sync code)
+- Prefer tokio::sync primitives over std::sync in async code
+- Use channels for task communication instead of shared state when possible
+- Always handle JoinHandle results (tasks can panic)
+- Use select! for cancellation patterns
+- Avoid holding locks across .await points
+- Use timeout for all external I/O operations
+- Implement graceful shutdown with channels
+- Use async-trait for trait-based async code
+- Prefer try_join! over manual error handling
+- Use Arc<Mutex<T>> sparingly (channels often better)
+- Test async code with tokio::test macro
+- Monitor task spawning to prevent unbounded growth

--- a/.claude/skills/rust-engineer/references/documentation.md
+++ b/.claude/skills/rust-engineer/references/documentation.md
@@ -1,0 +1,47 @@
+# Documentation and Comments
+
+Use comments and docs to preserve intent, not to narrate syntax.
+
+## Public APIs
+
+Use `///` doc comments for public items:
+
+- what the API does
+- important invariants
+- error conditions
+- panic conditions, if any
+- examples worth turning into doctests
+
+## Inline Comments
+
+Use `//` comments for:
+
+- non-obvious design choices
+- workarounds with a real reason
+- concurrency or memory-ordering rationale
+- safety invariants before `unsafe`
+
+Bad comments restate code. Good comments explain why the code has this shape.
+
+## `SAFETY:` Comments
+
+Every `unsafe` block should have a nearby `SAFETY:` comment stating the invariant that makes the block sound.
+
+```rust
+// SAFETY: `ptr` came from `Vec::as_mut_ptr`, `len` elements are initialized,
+// and `dst` does not overlap `src`.
+unsafe {
+    std::ptr::copy_nonoverlapping(src, dst, len);
+}
+```
+
+## TODOs
+
+TODOs should be actionable and traceable. Prefer a linked issue or enough context that another maintainer can finish the work later.
+
+## Review Checklist
+
+- Does the doc comment explain contract, errors, and examples for the public API?
+- Does the inline comment explain why, not what?
+- Does every `unsafe` block have a `SAFETY:` explanation?
+- Should this example become a doctest?

--- a/.claude/skills/rust-engineer/references/error-handling.md
+++ b/.claude/skills/rust-engineer/references/error-handling.md
@@ -1,0 +1,118 @@
+# Error Handling in Rust
+
+Model failure explicitly. Good Rust error handling makes call sites simpler, not noisier.
+
+## Choose the Right Error Surface
+
+- `Option<T>`: absence is expected and uninteresting
+- `Result<T, E>`: the caller should know why the operation failed
+- `panic!`: unrecoverable bug or violated invariant, not normal control flow
+
+```rust
+fn find_user(id: u64) -> Option<User> {
+    USERS.get(&id).cloned()
+}
+
+fn parse_port(raw: &str) -> Result<u16, std::num::ParseIntError> {
+    raw.parse()
+}
+```
+
+## Use `thiserror` for Libraries and Reusable Modules
+
+Use typed errors when the caller may branch on failure kinds, log them structurally, or expose them across crate boundaries.
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to read config from {path}")]
+    Read {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("invalid port `{raw}`")]
+    InvalidPort {
+        raw: String,
+        #[source]
+        source: std::num::ParseIntError,
+    },
+}
+
+fn load_port(path: &str) -> Result<u16, ConfigError> {
+    let raw = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.to_owned(),
+        source,
+    })?;
+
+    raw.trim().parse().map_err(|source| ConfigError::InvalidPort {
+        raw,
+        source,
+    })
+}
+```
+
+## Use `anyhow` at Application Boundaries
+
+`anyhow` is good for binaries, CLIs, jobs, and orchestration layers that mostly need context-rich propagation rather than a public error enum.
+
+```rust
+use anyhow::{Context, Result, ensure};
+
+fn run(path: &str) -> Result<()> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read config at {path}"))?;
+
+    ensure!(!raw.trim().is_empty(), "config file is empty");
+    Ok(())
+}
+```
+
+## Prefer `?` Plus Context Over Manual Match Chains
+
+```rust
+use anyhow::{Context, Result};
+
+fn read_user_id(path: &str) -> Result<u64> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {path}"))?;
+    let id = raw.trim().parse().context("parsing user id")?;
+    Ok(id)
+}
+```
+
+Add context where it helps the next debugging step. Do not restate what the underlying error already says.
+
+## Conversions
+
+Use `#[from]` or explicit `map_err` conversions instead of `Box<dyn Error>` unless you truly need heterogeneous dynamic errors at a boundary.
+
+## `unwrap()` and `expect()`
+
+Default rule:
+
+- Avoid both in production logic.
+- Use them in tests, examples, and setup code when failure should abort the test immediately.
+- Use `expect()` in production only for an invariant that is genuinely impossible in correct code, and make the message explain the invariant.
+
+That is an exception, not the design default.
+
+## Async Error Boundaries
+
+In async code, separate these failure classes:
+
+- task join failure
+- timeout or cancellation
+- domain failure inside the task
+
+Do not collapse them into one vague string if the caller can recover differently.
+
+## Review Checklist
+
+- Should this be `Option` or `Result`?
+- Does the error type match the boundary: typed for libraries, `anyhow` for apps?
+- Is context attached where it helps locate the failure?
+- Are panics limited to bugs, tests, or impossible invariants?
+- Would a caller need to branch on this error later? If yes, avoid erasing it too early.

--- a/.claude/skills/rust-engineer/references/linting.md
+++ b/.claude/skills/rust-engineer/references/linting.md
@@ -1,0 +1,40 @@
+# Linting and Mechanical Discipline
+
+Linting is not cosmetic in Rust. It catches real API-shape problems, accidental allocation, style drift, and bug-prone patterns.
+
+## Default Command
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+```
+
+Use narrower scope only when the workspace genuinely requires it.
+
+## What to Fix First
+
+- `redundant_clone`
+- `needless_collect`
+- `large_enum_variant`
+- `map_err_ignore`
+- `await_holding_lock`
+- `unused_async`
+- conversion and allocation warnings that reveal a bad boundary
+
+The point is not to satisfy clippy mechanically. The point is to fix the underlying shape that caused the warning.
+
+## Suppressions
+
+Default to fixing the code. If a lint is a false positive or the tradeoff is intentional:
+
+- scope the suppression as narrowly as possible
+- document the reason inline
+- prefer `#[expect(...)]` when supported by the project toolchain
+
+Never silence a warning just to get the build green.
+
+## Review Checklist
+
+- Did clippy expose a deeper ownership or allocation problem?
+- Is a warning caused by an overly concrete API like `&String` or `Vec<T>` parameters?
+- Is an async warning really pointing to a blocking or lock-lifetime bug?
+- Is a suppression local, justified, and stable?

--- a/.claude/skills/rust-engineer/references/ownership.md
+++ b/.claude/skills/rust-engineer/references/ownership.md
@@ -1,0 +1,124 @@
+# Ownership, Borrowing, and API Shape
+
+Choose the smallest, most flexible type that matches the contract. Most Rust API quality problems start here.
+
+## Prefer Borrowed Inputs for Read-Only Data
+
+Use the borrowed view type, not the owned container type, when the function only reads data:
+
+| Need | Prefer | Avoid |
+| --- | --- | --- |
+| text | `&str` | `&String` |
+| bytes | `&[u8]` | `&Vec<u8>` |
+| slice-like data | `&[T]` | `&Vec<T>` |
+| filesystem paths | `&Path` | `&PathBuf` |
+
+```rust
+use std::path::Path;
+
+fn parse_name(input: &str) -> usize {
+    input.trim().len()
+}
+
+fn checksum(bytes: &[u8]) -> u32 {
+    bytes.iter().fold(0, |acc, b| acc + u32::from(*b))
+}
+
+fn open_config(path: &Path) -> std::io::Result<String> {
+    std::fs::read_to_string(path)
+}
+```
+
+Take ownership only when the function must store the value, mutate and return it, move it into a task, or otherwise outlive the caller's borrow.
+
+## Borrowing Beats Cloning
+
+Clone because ownership is required, not because lifetimes feel inconvenient.
+
+```rust
+fn count_non_zero(data: &[u8]) -> usize {
+    data.iter().filter(|&&byte| byte != 0).count()
+}
+
+fn spawn_job(name: String) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        println!("running {name}");
+    })
+}
+```
+
+If ownership is conditional, use `Cow<'_, T>` rather than eagerly allocating.
+
+```rust
+use std::borrow::Cow;
+
+fn normalize(input: &str) -> Cow<'_, str> {
+    if input.contains('\t') {
+        Cow::Owned(input.replace('\t', " "))
+    } else {
+        Cow::Borrowed(input)
+    }
+}
+```
+
+## Lifetimes
+
+Write explicit lifetimes when the relationship matters to the reader or the compiler.
+
+```rust
+fn longest<'a>(left: &'a str, right: &'a str) -> &'a str {
+    if left.len() >= right.len() { left } else { right }
+}
+
+struct Excerpt<'a> {
+    part: &'a str,
+}
+```
+
+Do not add explicit lifetimes just because the code is generic. Add them when they describe a real borrowing relationship.
+
+## Smart Pointer Selection
+
+- `Box<T>`: single owner, heap allocation
+- `Rc<T>`: shared ownership on one thread
+- `Arc<T>`: shared ownership across threads
+- `RefCell<T>`: interior mutability with runtime borrow checks on one thread
+- `Mutex<T>` / `RwLock<T>`: synchronized interior mutability across threads
+
+Combine pointers only when the ownership model truly requires it. `Rc<RefCell<T>>` and `Arc<Mutex<T>>` are legitimate tools, but they are also a signal that mutation and sharing are both central to the design.
+
+## `Send` and `Sync`
+
+Use these rules when debugging thread-boundary failures:
+
+- `T: Send` means ownership of `T` can move to another thread
+- `T: Sync` means `&T` can be shared across threads
+- `&mut T` is exclusive access, so it is not `Sync`
+- `Rc<T>` is neither `Send` nor `Sync`
+- `Arc<T>` is `Send`/`Sync` only if `T` is `Send`/`Sync`
+
+When a spawned Tokio task fails trait bounds, inspect the captured values first. One non-`Send` capture is usually the real cause.
+
+## Interior Mutability
+
+Use interior mutability for a reason:
+
+- `Cell<T>` for tiny `Copy` values
+- `RefCell<T>` for single-threaded mutation hidden behind an immutable API
+- `Mutex<T>` / `RwLock<T>` for cross-thread shared mutation
+
+Keep lock lifetimes short, and never hold a lock across `.await` unless the design explicitly requires an async-aware lock and the critical section is intentional.
+
+## Pin
+
+Most code should not mention `Pin`. Reach for it when implementing lower-level async, self-referential, or intrusive structures where movement after initialization would be unsound.
+
+Document every `unsafe` block that interacts with pinning using a `SAFETY:` comment that states the invariant.
+
+## Practical Review Checklist
+
+- Could this argument be `&str`, `&[T]`, or `&Path` instead of `&String`, `&Vec<T>`, or `&PathBuf`?
+- Is a clone required by ownership, or just masking an avoidable borrow/lifetime issue?
+- Is shared mutable state necessary, or would message passing or plain borrowing be simpler?
+- Are `Send`/`Sync` requirements explicit at thread or task boundaries?
+- Is `Pin` solving a real immovability problem, not just appearing because async code exists?

--- a/.claude/skills/rust-engineer/references/performance.md
+++ b/.claude/skills/rust-engineer/references/performance.md
@@ -1,0 +1,50 @@
+# Performance Mindset
+
+Measure first. Rust often makes it easy to write fast code, but it also makes it easy to cargo-cult “optimizations” that add complexity with no user-visible win.
+
+## Baseline Rules
+
+- Benchmark and profile with release builds
+- Fix obvious allocation pressure before reaching for unsafe or complex abstractions
+- Prefer data-shape fixes over micro-optimizations
+
+## Common Real Problems
+
+### Redundant Cloning
+
+Look for:
+
+- cloning in loops
+- cloning just to satisfy an avoidable ownership boundary
+- cloning large maps or vectors instead of borrowing, slicing, or using `Cow`
+
+### Needless Allocation
+
+Look for:
+
+- `format!` where borrowed formatting or `write!` would do
+- `collect::<Vec<_>>()` followed immediately by iteration
+- `String` or `Vec<T>` parameters where a borrowed view would work
+
+### Dispatch Costs
+
+Prefer static dispatch in hot paths. Use `dyn Trait` when heterogeneity, plugin-style boundaries, or reduced code size is the point.
+
+### Data Layout
+
+Large enums, oversized structs, and pointer-heavy graphs can matter more than a clever loop rewrite.
+
+## Tooling
+
+- `cargo bench`
+- `criterion`
+- `cargo flamegraph` or platform-appropriate profilers
+- `cargo clippy -- -D clippy::perf`
+
+## Review Checklist
+
+- Was the performance problem measured?
+- Is cloning or allocation happening because of a bad API boundary?
+- Would a borrowed input or iterator pipeline remove the cost entirely?
+- Is dynamic dispatch present for a real design reason?
+- Is the optimization making invariants harder to maintain than the win justifies?

--- a/.claude/skills/rust-engineer/references/testing.md
+++ b/.claude/skills/rust-engineer/references/testing.md
@@ -1,0 +1,136 @@
+# Testing in Rust
+
+Tests should attack the contract, not mirror the implementation.
+
+## Test Selection
+
+- Unit tests: function-level behavior and edge cases
+- Integration tests: crate boundaries, public workflows, CLI behavior, serialization, persistence
+- Doctests: public API usage examples
+- Property tests: invariants across many inputs
+- Snapshot tests: stable generated output
+- Benchmarks: performance questions only after correctness is established
+
+## Naming and Scope
+
+Prefer names that state behavior and condition:
+
+```rust
+#[test]
+fn parse_port_returns_error_when_value_is_out_of_range() {}
+```
+
+Target one behavior per test. Multiple assertions are fine when they all prove the same behavior; avoid giant “kitchen sink” tests.
+
+Organize tests around the unit of work:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod parse_port {
+        use super::*;
+
+        #[test]
+        fn returns_error_when_input_is_empty() {
+            assert!(parse_port("").is_err());
+        }
+    }
+}
+```
+
+## Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_replaces_tabs() {
+        assert_eq!(normalize("a\tb"), "a b");
+    }
+
+    #[test]
+    fn normalize_borrows_when_no_change_is_needed() {
+        assert!(matches!(normalize("ab"), std::borrow::Cow::Borrowed("ab")));
+    }
+}
+```
+
+## Doctests
+
+Use doctests for public APIs that users are likely to copy.
+
+```rust
+/// Parses a TCP port from text.
+///
+/// ```
+/// let port = mylib::parse_port("8080").unwrap();
+/// assert_eq!(port, 8080);
+/// ```
+pub fn parse_port(raw: &str) -> Result<u16, std::num::ParseIntError> {
+    raw.parse()
+}
+```
+
+## Integration Tests
+
+Put cross-module or public workflow tests in `tests/`.
+
+```rust
+// tests/cli.rs
+#[test]
+fn config_command_reads_file_from_disk() {
+    // exercise the public boundary, not internal helpers
+}
+```
+
+Use shared helpers sparingly. If every test needs a complex harness, the production boundary may be too hard to drive.
+
+## Async Tests
+
+```rust
+#[tokio::test]
+async fn fetch_user_times_out_when_backend_hangs() {
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        fetch_user("42"),
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+```
+
+Test cancellation, timeout, and task-join behavior explicitly when they are part of the contract.
+
+## Property Tests
+
+Use `proptest` or similar for invariants:
+
+- parsing/formatting round trips
+- order preservation
+- idempotence
+- commutativity or associativity
+
+## Snapshot Tests
+
+Use snapshot tests for generated text, structured output, or diagnostics where diff quality matters more than hand-written assertions.
+
+- Keep snapshots small and intentional
+- Review every snapshot change as if it were code
+- Do not use snapshots to hide behavior you do not understand
+
+## Fixtures and Cleanup
+
+Prefer helpers that clean up automatically with `Drop`, tempdirs, or test transactions. Avoid global mutable state unless the test runner forces it.
+
+## Review Checklist
+
+- Does the test fail for the bug you care about, not just for any bug?
+- Is the test exercising the owning layer of the behavior?
+- Is the name specific about behavior and condition?
+- Would a simpler assertion prove the same claim?
+- Should this be a doctest, integration test, property test, or snapshot instead?

--- a/.claude/skills/rust-engineer/references/traits.md
+++ b/.claude/skills/rust-engineer/references/traits.md
@@ -1,0 +1,413 @@
+# Traits, Generics, and Type System
+
+## Basic Trait Definition
+
+```rust
+// Simple trait
+trait Drawable {
+    fn draw(&self);
+}
+
+// Trait with default implementation
+trait Describable {
+    fn describe(&self) -> String {
+        String::from("No description available")
+    }
+}
+
+// Implementing traits
+struct Circle {
+    radius: f64,
+}
+
+impl Drawable for Circle {
+    fn draw(&self) {
+        println!("Drawing circle with radius {}", self.radius);
+    }
+}
+
+impl Describable for Circle {
+    fn describe(&self) -> String {
+        format!("A circle with radius {}", self.radius)
+    }
+}
+```
+
+## Associated Types
+
+```rust
+// Associated types vs generic parameters
+trait Container {
+    type Item;
+
+    fn add(&mut self, item: Self::Item);
+    fn get(&self, index: usize) -> Option<&Self::Item>;
+}
+
+impl Container for Vec<i32> {
+    type Item = i32;
+
+    fn add(&mut self, item: i32) {
+        self.push(item);
+    }
+
+    fn get(&self, index: usize) -> Option<&i32> {
+        self.get(index)
+    }
+}
+
+// Iterator trait (standard library example)
+trait MyIterator {
+    type Item;
+
+    fn next(&mut self) -> Option<Self::Item>;
+}
+```
+
+## Generic Traits and Bounds
+
+```rust
+// Generic trait with multiple bounds
+fn print_info<T>(item: &T)
+where
+    T: std::fmt::Display + std::fmt::Debug,
+{
+    println!("Display: {}", item);
+    println!("Debug: {:?}", item);
+}
+
+// Generic struct with trait bounds
+struct Pair<T: PartialOrd> {
+    first: T,
+    second: T,
+}
+
+impl<T: PartialOrd> Pair<T> {
+    fn new(first: T, second: T) -> Self {
+        Self { first, second }
+    }
+
+    fn larger(&self) -> &T {
+        if self.first > self.second {
+            &self.first
+        } else {
+            &self.second
+        }
+    }
+}
+
+// Blanket implementation
+trait MyTrait {
+    fn do_something(&self);
+}
+
+impl<T: std::fmt::Display> MyTrait for T {
+    fn do_something(&self) {
+        println!("Value: {}", self);
+    }
+}
+```
+
+## Trait Objects (Dynamic Dispatch)
+
+```rust
+// Static dispatch (monomorphization)
+fn static_dispatch<T: Drawable>(item: &T) {
+    item.draw();
+}
+
+// Dynamic dispatch (trait objects)
+fn dynamic_dispatch(item: &dyn Drawable) {
+    item.draw();
+}
+
+// Storing trait objects
+struct Canvas {
+    shapes: Vec<Box<dyn Drawable>>,
+}
+
+impl Canvas {
+    fn new() -> Self {
+        Self { shapes: Vec::new() }
+    }
+
+    fn add_shape(&mut self, shape: Box<dyn Drawable>) {
+        self.shapes.push(shape);
+    }
+
+    fn draw_all(&self) {
+        for shape in &self.shapes {
+            shape.draw();
+        }
+    }
+}
+
+// Object safety: traits must meet criteria
+trait ObjectSafe {
+    fn method(&self);  // OK: takes &self
+}
+
+trait NotObjectSafe {
+    fn generic<T>(&self);  // NOT OK: generic method
+    fn by_value(self);     // NOT OK: takes self by value
+}
+```
+
+## Derive Macros
+
+```rust
+// Standard derive macros
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct User {
+    id: u64,
+    name: String,
+}
+
+// Deriving more traits
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+// Custom derive with serde
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Config {
+    host: String,
+    port: u16,
+}
+```
+
+## Advanced Trait Patterns
+
+```rust
+// Extension trait pattern
+trait StringExt {
+    fn truncate_to(&self, max_len: usize) -> String;
+}
+
+impl StringExt for str {
+    fn truncate_to(&self, max_len: usize) -> String {
+        if self.len() <= max_len {
+            self.to_string()
+        } else {
+            format!("{}...", &self[..max_len])
+        }
+    }
+}
+
+// Sealed trait pattern (prevent external implementation)
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait MySealed: sealed::Sealed {
+    fn method(&self);
+}
+
+struct MyType;
+impl sealed::Sealed for MyType {}
+impl MySealed for MyType {
+    fn method(&self) {
+        println!("Implemented");
+    }
+}
+
+// Supertraits
+trait Printable {
+    fn print(&self);
+}
+
+trait Loggable: Printable {  // Supertrait: must also impl Printable
+    fn log(&self) {
+        self.print();  // Can call supertrait methods
+    }
+}
+```
+
+## Associated Constants
+
+```rust
+trait Config {
+    const MAX_SIZE: usize;
+    const DEFAULT_TIMEOUT: u64;
+}
+
+struct ServerConfig;
+
+impl Config for ServerConfig {
+    const MAX_SIZE: usize = 1024;
+    const DEFAULT_TIMEOUT: u64 = 30;
+}
+
+fn use_config<T: Config>() {
+    println!("Max size: {}", T::MAX_SIZE);
+}
+```
+
+## Generic Associated Types (GATs)
+
+```rust
+// GATs allow generics in associated types
+trait LendingIterator {
+    type Item<'a> where Self: 'a;
+
+    fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+}
+
+struct WindowsMut<'data, T> {
+    data: &'data mut [T],
+    index: usize,
+}
+
+impl<'data, T> LendingIterator for WindowsMut<'data, T> {
+    type Item<'a> = &'a mut [T] where Self: 'a;
+
+    fn next<'a>(&'a mut self) -> Option<Self::Item<'a>> {
+        if self.index >= self.data.len() {
+            return None;
+        }
+
+        let start = self.index;
+        self.index += 2;
+
+        Some(&mut self.data[start..start.min(self.data.len())])
+    }
+}
+```
+
+## Marker Traits
+
+```rust
+use std::marker::{PhantomData, Send, Sync};
+
+// Send: type can be transferred across thread boundaries
+// Sync: type can be shared between threads (&T is Send)
+
+// Custom marker trait
+trait Trusted {}
+
+struct TrustedData<T> {
+    data: T,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Trusted> TrustedData<T> {
+    fn new(data: T) -> Self {
+        Self {
+            data,
+            _marker: PhantomData,
+        }
+    }
+}
+```
+
+## Operator Overloading
+
+```rust
+use std::ops::{Add, Mul};
+
+#[derive(Debug, Clone, Copy)]
+struct Vector2D {
+    x: f64,
+    y: f64,
+}
+
+impl Add for Vector2D {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl Mul<f64> for Vector2D {
+    type Output = Self;
+
+    fn mul(self, scalar: f64) -> Self {
+        Self {
+            x: self.x * scalar,
+            y: self.y * scalar,
+        }
+    }
+}
+
+// Usage
+let v1 = Vector2D { x: 1.0, y: 2.0 };
+let v2 = Vector2D { x: 3.0, y: 4.0 };
+let v3 = v1 + v2;
+let v4 = v1 * 2.5;
+```
+
+## From/Into Conversion Traits
+
+```rust
+struct UserId(u64);
+
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        UserId(id)
+    }
+}
+
+// Into is automatically implemented
+fn accept_user_id(id: impl Into<UserId>) {
+    let user_id = id.into();
+    println!("User ID: {}", user_id.0);
+}
+
+// TryFrom for fallible conversions
+use std::convert::TryFrom;
+
+impl TryFrom<i64> for UserId {
+    type Error = &'static str;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        if value < 0 {
+            Err("User ID cannot be negative")
+        } else {
+            Ok(UserId(value as u64))
+        }
+    }
+}
+```
+
+## Const Traits (Nightly)
+
+```rust
+// Const trait implementations (requires nightly)
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait ConstAdd {
+    fn add(self, other: Self) -> Self;
+}
+
+impl const ConstAdd for i32 {
+    fn add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+const fn compute() -> i32 {
+    5.add(10)  // Can use in const context
+}
+```
+
+## Best Practices
+
+- Prefer associated types when there's one clear type per implementation
+- Use generic parameters when multiple types might be used simultaneously
+- Keep traits small and focused (single responsibility)
+- Use extension traits to add functionality to existing types
+- Document trait requirements and invariants
+- Use marker traits for compile-time guarantees
+- Prefer static dispatch for performance, dynamic dispatch for flexibility
+- Use #[derive] when possible instead of manual implementations
+- Implement standard traits (Debug, Clone, etc.) for better ecosystem integration
+- Use sealed traits to prevent external implementations when needed

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: testing
+description: Write tests and debug systematically.
+---
+
+# Testing & Debugging Skill
+
+## 🔴 CORE PHILOSOPHY
+
+If the repo has test-law or runner-ownership docs, read them first. Tests discover bugs, not pass. Fix code, not tests.
+
+**TEST LAYER SELECTION IS NON-NEGOTIABLE:**
+- Default to unit/integration/contract tests
+- **NEVER** use Playwright for backend, auth, routing, DB, workers, containers, preview lifecycle, WebSocket protocol, or service networking
+- Use Playwright only when DOM/rendering/iframe/real user interaction is the contract
+
+## Test-Driven Development (TDD)
+
+### TDD Workflow
+
+1. **Write failing test** - Describes desired behavior
+2. **Write minimal code** - Makes test pass
+3. **Refactor** - Improve code quality
+4. **Verify** - Run test 10 times to ensure it's not luck
+
+### Test Structure Pattern
+
+```javascript
+test("should do something", async ({ page }) => {
+  // 1. SETUP - Create isolated test data
+  const user = await createTestUser(page);
+  await registerUser(page, user);
+  await login(page, user);
+
+  // 2. ACTION - Perform test action
+  await page.click('button:has-text("Spawn Agent")');
+
+  // 3. ASSERTION - Verify expected behavior
+  await expect(page.locator("text=Agent spawned")).toBeVisible();
+
+  // 4. CLEANUP (optional - only if needed)
+});
+```
+
+### Test Isolation Rules
+
+**ALWAYS create unique test data:**
+
+```javascript
+// ❌ WRONG - Hardcoded (fails on second run)
+const user = { email: "test@example.com", password: "test" };
+
+// ✅ CORRECT - Unique every run
+const user = {
+  email: `test-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`,
+  password: `Pass-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  name: `TestUser-${Date.now()}`,
+};
+```
+
+**NEVER depend on:**
+- Hardcoded demo users (alice@demo.com)
+- Existing database state
+- Seed scripts
+
+### API Setup Over UI Clicking
+
+```javascript
+// ✅ PREFER - API calls or fixtures (fast, reliable)
+const auth = await createApiAuth(page);
+await page.request.post(`${env.baseURL}/api/resources`, {
+  headers: auth.headers,
+  data: buildFixture(),
+});
+
+// ❌ AVOID - UI clicking (slow, brittle)
+await page.click('button:has-text("New Project")');
+await page.fill('input[name="name"]', "Test Project");
+await page.click('button:has-text("Create")');
+```
+
+## 🔴 THE DELETION TEST — Assertion Value (MOST IMPORTANT SECTION)
+
+**A test is theatre when no realistic production bug could make it fail.** Before committing ANY test: mentally delete the implementation. If the test still passes, the test is WORTHLESS.
+
+**The deletion test asks:** would deleting the implementation make this test fail? If not, the test is theatre.
+
+**Regression tests from postmortems:** apply a **Contract-Restatement Gate** before writing the test. Restate the behavior without incident-only names, file paths, dates, or identifiers. The primary test should assert the general contract; incident breadcrumbs belong in comments or an optional secondary tripwire.
+
+### Worthless vs Valuable Assertions
+
+| Worthless (shape/wiring) | Why it's worthless | Valuable (behavioral) |
+|---|---|---|
+| `expect(result).toBeInstanceOf(X)` | Passes with empty stub | `expect(result.compute(input)).toBe(output)` |
+| `expect(mock).toHaveBeenCalledWith(args)` | Verifies wiring | `expect(actualSideEffect).toBe(expected)` |
+| `expect(config).toHaveProperty('key')` | Shape theater | Feed config to consumer, verify outcome |
+| `expect(response.status).toBe(200)` (all mocked) | Mock returns 200 | Hit real handler with edge cases |
+| `expect(factory(type)).toBeInstanceOf(Impl)` | Constructor dispatch | `factory(type).execute(input)` produces right output |
+| `expect(true).toBe(true)` | Tautological — always passes | Delete entirely, assert real behavior |
+| `expect(typeof X).toBe('function')` | TS compilation already proves this | Test what X does with real input |
+
+### What is NOT Theatre (Prevent Overcorrection)
+
+| Pattern | Why it's valid |
+|---|---|
+| `toBeDefined()` as guard before deeper assertions | Prevents cryptic errors on next line |
+| `.rejects.toBeInstanceOf(Error)` | Tests error path — swallowed error would fail |
+| `toBeInstanceOf` alongside behavioral assertions | Behavioral assertion is the proof; instanceof is supplementary |
+| Cross-boundary shape checks | Shape IS the contract when consumer is external |
+| `toHaveBeenCalledWith()` verifying computed values | Mock exposes what logic COMPUTED |
+
+### Cross-Boundary Contract Tests (HIGHEST VALUE)
+
+The most valuable tests verify that System A's output actually works when consumed by System B:
+
+```javascript
+// ❌ SHAPE: adapter config has right keys
+expect(config.servers).toHaveProperty('code-intelligence');
+expect(config.servers['code-intelligence'].command).toBe('node');
+
+// ✅ CONTRACT: adapter config actually starts the MCP server
+const config = adapter.generateMcpConfig();
+const out = await dockerRun(image, `node -e "import('${config.serverPath}')"`)
+// Proves the output WORKS, not just that it has the right shape
+```
+
+### Mock Tests That DO Work
+
+Mocks are fine when they expose what business logic COMPUTED:
+
+```javascript
+// ✅ USEFUL - Verifies business logic via mock
+expect(mockRuntime.getLastHealthCheckUrl()).toBe(`http://127.0.0.1:${port}/health`);
+expect(mockProvisioner.getLastResourceName()).toBe(`job-${workspaceId}-${runId}`);
+expect(mockProvisioner.getCalls('start')[0].args.command).toContain('--workspace');
+```
+
+**Mocks MUST implement:** `getCalls(method?)`, `getLastX()` convenience methods. Track ALL arguments.
+
+### Testing Strategy
+
+| Tier | What It Catches | Speed | When |
+|---|---|---|---|
+| Unit (behavioral assertions) | Logic bugs, edge cases | Fast | Every PR |
+| Contract (cross-boundary) | Integration bugs, config drift | Medium | Every PR |
+| Real Docker/integration | Environment bugs | Slow | Nightly |
+
+## Systematic Debugging Methodology
+
+### 6-Step Debugging Process
+
+| Step | Action | Key Question |
+|------|--------|--------------|
+| 1. Reproduce | Run 10 times, document exact steps | Does it fail consistently? |
+| 2. Isolate | Minimal reproduction (10 lines), remove Docker/network/DB | What's the MINIMAL failing setup? |
+| 3. Understand | Read failing code, trace execution, verify assumptions | What ACTUALLY happens vs expected? |
+| 4. Fix | Root cause only, document WHY | WHY did it fail? (not just WHAT) |
+| 5. Verify | Run 10 times, test edge cases | Lucky once, or actually fixed? |
+| 6. Prevent | Add test for this bug, update repo docs/skills/checks if needed | How to catch this early? |
+
+### Log Investigation Pattern
+
+❌ "Let me check the logs" → ✅ "HTTP 500 - checking the owning service logs for the stack trace, THEN reading failing code"
+
+**ALWAYS:** WHICH logs → WHAT looking for → WHAT you'll do with it
+
+### Debugging Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|--------------|----------------|------------------|
+| Trial and error | Guessing wastes time | Check ACTUAL values first, trace why wrong |
+| Blame cache | Cache is rarely the issue | Check headers, state flow, API responses |
+| Hide with try-catch | Error still exists | Find WHY it throws, fix root cause |
+| Add fallbacks | Masks real bug | Ask WHY value is undefined, fix source |
+
+## Root Cause Analysis
+
+| Principle | What To Do |
+|-----------|------------|
+| Ask WHY until bedrock | Network issue? WHY → Port conflict? WHY → Race condition? WHY → Keep digging |
+| Isolate | 5-line reproduction > 10,000 lines. Remove Docker/network/DB. Change ONE thing. |
+| No shortcuts | Stop guessing. No workarounds. "Probably works" → RUN IT. |
+| Real environment | Test in Docker if prod uses Docker. Real data. Test failure modes. 10x runs. |
+
+## Test Commands Reference
+
+### Unit Tests
+
+Use the owning unit-test command for the repo and run the narrowest possible slice first.
+
+```bash
+npm test -- path/to/spec.test.ts
+pnpm test path/to/spec.test.ts
+cargo test failing_case_name
+pytest tests/unit/test_module.py -k failing_case
+```
+
+### Integration / Contract Tests
+
+Run the smallest real cross-boundary check that can prove the behavior.
+
+```bash
+npm run test:integration -- path/to/spec.test.ts
+pnpm test:contract
+pytest tests/integration/test_api.py -k failing_case
+cargo test --test api_contract
+```
+
+### Playwright Tests (Browser Contracts Only)
+
+```bash
+# USE ONLY when the browser is required to observe the bug.
+npx playwright test path/to/spec.ts
+npx playwright test --headed
+npx playwright test --project=chromium
+```
+
+**If the browser is not required, STOP and build the lower-layer test instead.**
+
+## Tooling Cheatsheet
+
+**JavaScript/TypeScript:**
+- DevTools breakpoints, `console.table`, `performance.mark`
+- VS Code launch configs
+
+**Node:**
+- `--inspect`, `--trace-warnings`, `--trace-deprecation`
+- `clinic flame` for profiling
+
+**Database:**
+- use the repo's canonical query tool or local client (`psql`, `sqlite3`, ORM shell, seeded fixtures)
+- verify the exact rows or records involved in the failure rather than guessing from app behavior
+
+**Docker:**
+- `docker compose logs -f <service>`
+- `docker ps -a`
+- `docker inspect <container-id>`
+- `docker stats`
+
+**Git:**
+- `git bisect` - binary search for regressions
+- `git log --oneline --since="2 days ago"`
+
+## Red Flags (You're Guessing)
+
+- Adding retries/timeouts "just because"
+- Silencing errors instead of finding source
+- Dismissing areas with "it can't be that"
+- Skipping reproduction or minimal case
+- Not diffing working vs broken paths
+
+## ALWAYS - Not Suggestions, Requirements
+
+- **ALWAYS find root cause before fixes** - No band-aids
+- **ALWAYS isolate to minimal reproduction**
+- **ALWAYS verify in realistic environment**
+- **ALWAYS create isolated test data** - Unique emails
+- **ALWAYS investigate test failures** - They found bugs
+- **ALWAYS update repo-local test docs/checks when the failure exposes a reusable rule**
+
+## NEVER - These Will Break You
+
+- **NEVER accept "it doesn't work" as an answer**
+- **NEVER apply fixes without understanding root cause**
+- **NEVER skip verification**
+- **NEVER weaken tests to make them pass**
+- **NEVER depend on demo users**
+- **NEVER modify system code to make tests pass**
+- **NEVER use `.skip()` or comment out tests**
+
+## PREFER - Better Ways Exist
+
+- **PREFER understanding over trial-and-error**
+- **PREFER minimal reproduction** - 10 lines beats 1000
+- **PREFER root cause fixes over workarounds**
+- **PREFER API calls for test setup**
+- **PREFER unique identifiers** - `user-${Date.now()}`
+- **PREFER semantic assertions** - `toBeVisible()` beats `toBeTruthy()`
+
+## Regression Prevention
+
+After fixing a bug:
+
+1. **Add targeted test** (unit/integration/E2E) for root cause
+2. **Add logs/metrics/traces** around fault domain
+3. **Document the fix** in issue/PR for future recall
+4. **Update repo-local docs/skills/checks** with reusable lessons learned
+5. **Delete workarounds** added during debugging

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: typescript
+description: Write strict TS/React/Node code.
+---
+
+# TypeScript Development Guidelines
+
+## TypeScript Fundamentals
+
+- ALWAYS use strict TypeScript - no `any` unless absolutely necessary
+- ALWAYS define explicit return types for functions
+- ALWAYS use interfaces for object shapes, types for unions/primitives
+- PREFER `unknown` over `any` when type is truly unknown
+- USE type guards for runtime type narrowing
+
+### Nullable Types
+
+**DO NOT USE `?` or `| null | undefined` UNLESS ABSOLUTELY NECESSARY**
+
+- Adding `?` to avoid type error = WRONG. Fix root cause instead.
+- Required config, function params = non-nullable
+- Only nullable: DB nulls, optional API fields, optional user input
+
+### Strict Mode: Optional Chaining vs Explicit Checks
+
+**When `strict: true` is enabled, choose the right pattern for each case:**
+
+```typescript
+// ❌ WRONG - Optional chaining creates incompatible types
+const userId = req.user?.userId  // Type: string | undefined
+if (!userId || !teamId) { ... }  // Works but userId still typed as possibly undefined
+
+// ✅ PATTERN 1: Explicit null check (PREFERRED)
+if (!req.user || !req.user.userId) {
+  return res.status(401).json({ error: 'Unauthorized' })
+}
+const userId = req.user.userId  // Type: string (narrowed by check)
+
+// ✅ PATTERN 2: Logical AND (when assigning to variable for null check)
+const userId = req.user && req.user.userId
+if (!userId) { return res.status(401) }
+
+// ✅ PATTERN 3: Optional chaining (when genuinely optional)
+const optionalField = user?.preferences?.theme  // OK if undefined is valid
+```
+
+**Removing Non-Null Assertions (`!`)**
+
+```typescript
+// ❌ FORBIDDEN - Non-null assertion bypasses safety
+const agentId = req.params["id"]!;
+const user = await findUser(userId!);
+
+// ✅ CORRECT - Let TypeScript infer from checks
+const agentId = req.params["id"]; // Already string, no ! needed
+if (!req.user?.userId) {
+  return res.status(401);
+}
+const user = await findUser(req.user.userId); // Safe after check
+```
+
+**When to use each:**
+
+- **Explicit checks**: Authenticated middleware values (`req.user`, `req.params.id`)
+- **Optional chaining**: Optional API fields, UI preferences, nullable DB columns
+- **Logical AND**: Rare - only when explicit check is unnecessarily verbose
+
+(LESSON LEARNED 2025-12-08)
+
+## React Patterns (Frontend)
+
+- USE functional components with hooks (no class components)
+- PREFER named exports over default exports
+- USE TypeScript generics for reusable components
+- DEFINE prop interfaces explicitly: `interface Props { ... }`
+- USE `React.FC<Props>` sparingly - prefer explicit function signatures
+
+## Node.js/Express (Backend)
+
+- USE ESM modules (`import`/`export`), not CommonJS
+- DEFINE request/response types for API endpoints
+- USE middleware typing: `RequestHandler`, `ErrorRequestHandler`
+- ALWAYS handle async errors with try/catch or error middleware
+
+## Layering Patterns
+
+- Frontend: keep UI types close to the UI code that owns them
+- Backend: keep handler/service types close to the server layer that owns them
+- Shared types: define them in the consuming package unless they are a real cross-boundary contract
+- API types: derive from validated contracts or generated schema types where applicable
+
+## Development Workflow
+
+### Auto-Reload (Docker Development)
+
+**NEVER manually restart containers for TypeScript code changes!**
+
+- ✅ **Frontend (.tsx, .ts, .css)** → Vite HMR picks up instantly (1-2 seconds)
+- ✅ **Backend (.ts files)** → Nodemon + esbuild auto-rebuild (2-3 seconds)
+- ✅ **Config files** → Usually picked up by HMR/nodemon
+
+**Just save and wait 2-3 seconds.** Check logs to see reload:
+
+```bash
+docker compose logs -f backend   # See nodemon rebuild
+docker compose logs -f frontend  # See Vite HMR
+```
+
+### When Restart IS Required
+
+Only restart for these changes:
+
+- ❌ `package.json` → New dependencies
+- ❌ `.env` → Environment variables
+- ❌ `Dockerfile` → Container config
+- ❌ `docker-compose.yml` → Service config
+
+```bash
+# After package.json changes
+docker compose build backend && docker compose up -d
+
+# After .env changes
+docker compose restart backend
+```
+
+## Type Checking Workflow
+
+**Run type checking WHEN DONE with implementation (not after every single edit):**
+
+```bash
+# Frontend
+cd client && npm run type-check
+
+# Backend
+cd server && npm run type-check
+```
+
+**When to type check:**
+
+- ✅ After completing a feature or fix
+- ✅ Before committing changes
+- ✅ After refactoring
+- ❌ NOT after every single file edit (too slow)
+
+**IF TYPE ERRORS:**
+
+- ❌ DO NOT ignore or defer
+- ❌ DO NOT use `@ts-ignore` or `@ts-expect-error` to suppress
+- ✅ FIX the actual type issue IMMEDIATELY before moving on
+
+**Type checking catches:**
+
+- Missing imports
+- Wrong function signatures
+- Incorrect prop types
+- Null/undefined access bugs
+- Breaking API contract changes
+
+## 🔴 MANDATORY: Test Verification After Changes
+
+**Workflow:** Type check → Identify relevant tests → Run them → Fix failures → THEN done
+
+**Find tests:** Tests mirror src/ structure. Changed `server/src/routes/agents.ts` → check `tests/unit/server/routes/agents*.test.ts`
+
+```bash
+grep -r "FunctionName" tests/ --include="*.test.ts" -l   # By function
+cd tests && npx jest --testPathPattern="agents"          # Run matching
+```
+
+**If tests fail:** YOUR CODE IS WRONG. Fix it. Never skip "because it's small".
+
+## Common Mistakes to Avoid
+
+- Don't use `as` type assertions to bypass type errors - fix the actual type
+- Don't ignore TypeScript errors with `@ts-ignore` - fix the root cause
+- Don't mix ESM and CommonJS in the same codebase
+- Don't use `Function` type - use specific function signatures
+- Don't restart containers for code changes - trust nodemon/HMR
+- Don't skip type checking after edits - run `npm run typecheck`
+
+## 🚨 Debugging Anti-Patterns
+
+### NEVER Blame Cached State for Frontend Issues
+
+**If you think a frontend bug is caused by "cached state" - YOU ARE WRONG and overlooking the actual issue!**
+
+- ❌ "Must be browser cache" - NO, there's a real bug you're missing
+- ❌ "Clear localStorage" - NO, fix the actual state management issue
+- ❌ "Hard refresh will fix it" - NO, that's hiding a symptom, not fixing the cause
+- ❌ "React state is stale" - NO, you have a logic error in your component
+
+**Cached state is RARELY the actual problem. If you suspect it:**
+
+1. Stop and re-examine your assumptions
+2. Check network requests (DevTools Network tab)
+3. Check component props and state flow
+4. Check API response data
+5. Look for race conditions or async timing issues
+6. Check your actual code logic - the bug is almost certainly there
+
+**Real causes when you blame cache:**
+
+- API returning old/wrong data
+- Component not re-rendering when props change
+- State update logic is wrong
+- Race condition between async operations
+- WebSocket/polling not updating state correctly
+- Missing dependency in useEffect
+
+**Bottom line: "It's cached state" is almost always a red herring. Find the real bug.**
+
+---
+
+## 🔴 ESLint Rules (Template Enforcement)
+
+**MECHANICALLY ENFORCED** - Violations FAIL builds. Error messages tell you WHY and HOW to fix.
+
+| Category | Rules | Key Fix |
+|----------|-------|---------|
+| **Security** | `react/no-danger`, `jsx-no-target-blank`, secrets detection | Use React auto-escaping, add `rel="noopener"`, use env vars |
+| **Memory Leaks** | `require-effect-cleanup`, `require-abort-controller`, `no-event-listener-leak` | ALWAYS return cleanup function in useEffect |
+| **Error Handling** | `no-empty`, `no-floating-promises`, `promise/catch-or-return` | NEVER empty catch, ALWAYS await/catch promises |
+| **Accessibility** | `alt-text`, `click-events-have-key-events`, `label-has-associated-control` | Images need alt, clickables need keyboard, labels need htmlFor |
+| **Magic Values** | `no-magic-numbers`, hardcoded URLs/timeouts | Extract to named constants, use env vars |
+| **React Perf** | `no-array-index-key`, `no-unstable-nested-components`, `jsx-key` | Use stable IDs, define components outside render |
+| **Type Safety** | `no-explicit-any`, `ban-ts-comment`, `explicit-function-return-type` | Use `unknown`, fix types properly, add return types |
+| **Testing** | `no-focused-tests`, `no-disabled-tests`, `expect-expect` | No `.only()/.skip()` committed, tests need assertions |
+| **CSS** | `declaration-no-important`, `forbid-component-props` (style) | Use classes, no inline styles |
+| **Complexity** | `complexity` (max 12), `max-depth` (4), `max-lines-per-function` (150) | Extract functions, reduce nesting |
+
+**54 rules total.** Error messages tell you exactly what's wrong and how to fix it.

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ dist/
 target/
 .ace/
 .agents/
-.claude/
+.claude/*
+!.claude/skills/
 .codex/
 .gemini/
 .opencode/

--- a/scripts/check-provenance.mjs
+++ b/scripts/check-provenance.mjs
@@ -86,11 +86,18 @@ function trackedFiles() {
     .filter((path) => path.length > 0 && existsSync(path));
 }
 
+// Hand-authored agent skills under .claude/skills/ are source of truth, not generated
+// runtime state, so they are the one allowed carve-out from the forbidden agent roots.
+function isForbiddenGeneratedRoot(path) {
+  if (path.startsWith(".claude/skills/")) return false;
+  return forbiddenGeneratedRoots.some((root) => path.startsWith(root));
+}
+
 function checkTrackedFile(path) {
   const entry = path.split("/").at(-1);
   if (forbiddenFileNames.has(entry)) throw new Error(`Forbidden Python packaging file in clean-room repo: ${path}`);
-  for (const root of forbiddenGeneratedRoots) {
-    if (path.startsWith(root)) throw new Error(`Generated/private runtime state must not be tracked: ${path}`);
+  if (isForbiddenGeneratedRoot(path)) {
+    throw new Error(`Generated/private runtime state must not be tracked: ${path}`);
   }
   if (path.endsWith(".tsbuildinfo")) throw new Error(`Generated TypeScript build info must not be tracked: ${path}`);
   if (path.startsWith("target/")) throw new Error(`Generated Rust target files must not be tracked: ${path}`);


### PR DESCRIPTION
## What
Adds the TypeScript + Rust engineering skills from the **covibes** and **orchestra** repos so opcore agents (zeroshot ships + Claude Code) follow the same code-quality standard.

- `.claude/skills/`: `typescript`, `rust-engineer` (+ `references/`), `rust-async-patterns`, `testing`, `eslint`, and a `repo-tooling` entry point extended to point agents at the language skills (the one skill zeroshot auto-injects into every cluster).
- Skills copied verbatim from covibes (byte-identical to orchestra).

## Why a provenance carve-out
opcore deliberately gitignores + provenance-forbids tracked `.claude/` (clean-room rule). Agent skills under `.claude/skills/` are hand-authored **source**, not generated runtime state, so this carves out **only** `.claude/skills/`:
- `check-provenance.mjs`: new `isForbiddenGeneratedRoot()` helper returns false for `.claude/skills/` (still forbids the rest of `.claude/`, `.agents/`, etc.). The refactor lowers `checkTrackedFile` complexity.
- `.gitignore`: `.claude/` → `.claude/*` + `!.claude/skills/`.

## Verified gate-safe
- `node scripts/check-provenance.mjs` passes with the tracked skills.
- `release-receipt:check` shells out to `check-provenance.mjs`, so the single carve-out also covers `npm run ci`.
- The launch-claim-scrub scans README/docs/packages only (never `.claude/`), so the skills' covibes/orchestra/crg/cix/rox mentions are not flagged.
- Rox scans `packages/scripts/tests/crates` only; `.claude/` is not packaged. No source/package/gate-behavior changes.

Foundation for a follow-up PR adding ESLint (advisory) + `rust-toolchain.toml` to bring the TS/Rust tooling setup to parity.
