### PR TITLE
feat: docs(ux): make first-run Opcore path simple and overclaim-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,45 +10,37 @@ agents. It starts with read-only repository scans, reports honest coverage
 before findings, and gives command-running agents a JSON gate for edits before
 they land.
 
-## Install and first run
+## First Run
 
-Start with the npx-first onboarding command from an existing repository:
+Run the onboarding wizard from an existing repository:
 
 ```bash
 npx @the-open-engine/opcore@0.1.0-alpha.0 init
 ```
 
-The first-run path scans before setup, prints Coverage before Findings, shows
-what Opcore can and cannot inspect, then asks for explicit approval before
-writing guidance, config, hooks, or ignore entries.
+`opcore init` detects supported stacks, runs a read-only first scan, prints
+Coverage before Findings, reports concrete counts and locations, proposes repo
+setup, and asks before writing anything.
+
+Scan/status/check/measure are read-only for source files. The scan loop writes
+only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded
+`.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`,
+one delimited guidance block in an existing agent file or new `AGENTS.md`, a
+managed `.opcore/` `.gitignore` line for Git repos, and
+`.opcore/init-undo.json`. Undo recorded setup with `opcore init --undo`.
+
+Agents and hooks should use the JSON contract `opcore check --changed --json`;
+humans do not need to learn that gate before onboarding.
 
 Install globally for repeat use:
 
 ```bash
-npx @the-open-engine/opcore@0.1.0-alpha.0 init
+npm install -g @the-open-engine/opcore@0.1.0-alpha.0
+opcore init
 ```
-
-The one-command onboarding path starts the interactive wizard in an existing
-project. It runs a read-only scan first, prints Coverage before Findings, says
-what Opcore can and cannot analyze, shows the additive setup plan, and asks for
-explicit approval before writing guidance, config, hooks, or ignore entries.
 
 Run bare `opcore` after install for the read-only scan loop. A scoped scan is
 available as `opcore --repo .`.
-
-## Repeat Use
-
-Install globally when you expect to run Opcore repeatedly:
-
-```bash
-npm install -g @the-open-engine/opcore@0.1.0-alpha.0
-opcore
-opcore --repo .
-opcore init --repo . --approve
-opcore check --changed --json
-opcore measure --repo .
-opcore try
-```
 
 `opcore init` is scan-first and ask-before-write on a TTY: it prints coverage
 before findings, shows the additive setup plan, then writes only after an
@@ -81,13 +73,13 @@ write should be blocked unless the caller has a typed recovery path.
 
 - Start with the useful loop: scan, init, check, measure.
 - Show coverage before findings.
-- Prefer concrete counts and file locations over scores.
+- Prefer concrete counts and file locations over a single rating.
 - Be honest about unsupported languages, missing tools, and degraded checks.
 - Keep ASP concepts behind the normal product path unless a user is installing
   providers or integrating a host.
 - Do not claim broad stack coverage, vulnerability auditing, autonomous repairs,
-  public standard status, or replacement of existing guardrails until evidence
-  proves it.
+  protocol status, or retirement of existing guardrails until evidence proves
+  it.
 
 Use `opcore check --staged --json` when the gate should inspect only staged
 content.
@@ -110,7 +102,7 @@ rating.
 | `opcore` | Read-only scan of the current repository. |
 | `opcore --repo .` | Read-only scan of an explicit repository path. |
 | `opcore status --json` | Read-only readiness and coverage status for tools. |
-| `opcore init --repo . --approve` | Scan-first, approval-gated setup that writes only additive guidance/config when approved. |
+| `opcore init --repo . --approve` | Scan-first setup that writes only the approved init artifacts. |
 | `opcore check --changed --json` | Changed-file JSON gate for agents. |
 | `opcore check --staged --json` | Staged-file JSON gate for pre-commit flows. |
 | `opcore measure --repo .` | Read stored scan history and report concrete deltas. |
@@ -120,10 +112,12 @@ rating.
 
 Opcore is a local CLI facade over scan, init, check, and measure flows. The
 accepted runtime model is hybrid: Rust graph core plus TypeScript contracts and
-CLI adapters. The scan path is read-only with respect to source files and writes
-only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded
-`.opcore/telemetry.jsonl`. Init is additive,
-approval-gated, and reversible through recorded undo metadata where supported.
+CLI adapters. Scan/status/check/measure are read-only for source files. The scan
+loop writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded
+`.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`,
+one delimited guidance block in an existing agent file or new `AGENTS.md`, a
+managed `.opcore/` `.gitignore` line for Git repos, and
+`.opcore/init-undo.json`.
 
 For the model behind coverage, findings, and degraded checks, see
 [Concepts: coverage and findings](docs/concepts.md). For the package and CLI

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,7 +6,7 @@ Opcore starts by counting the repository. TypeScript, JavaScript, Rust sources, 
 
 ## Findings
 
-Findings are named signals such as `typescript.type_errors`, `rust.source_hygiene`, and `coverage.unsupported_stacks`. Counts come from validation diagnostics, graph evidence when available, and repository census data. Opcore does not blend them into an opaque score.
+Findings are named signals such as `typescript.type_errors`, `rust.source_hygiene`, and `coverage.unsupported_stacks`. Counts come from validation diagnostics, graph evidence when available, and repository census data. Opcore does not blend them into a single rating.
 
 ## Artifacts
 
@@ -19,15 +19,19 @@ Allowed scan artifacts:
 ```
 
 Telemetry is bounded command latency evidence capped at 500 records or 1 MiB.
-`opcore measure` reads the report and history artifacts and reports
-baseline/previous deltas. It does not run checks, build graph data, install
-packages, or edit source.
+Scan/status/check/measure are read-only for source files. `opcore measure`
+reads the report and history artifacts and reports baseline/previous deltas. It
+does not run checks, build graph data, install packages, or edit source.
 
 ## Init
 
-`opcore init` is approval-gated. Without `--approve`, it returns a plan. With `--approve`, it writes additive `.opcore/config`, updates one delimited guidance block in existing agent files or creates `AGENTS.md`, appends one managed `.opcore/` line to `.gitignore` only in Git repos that do not already ignore it, and records `.opcore/init-undo.json`.
+`opcore init` is approval-gated. Without `--approve`, it returns a plan. With
+`--approve`, it writes only additive `.opcore/config`, one delimited guidance
+block in an existing agent file or new `AGENTS.md`, a managed `.opcore/` line in
+`.gitignore` for Git repos, and `.opcore/init-undo.json`.
 
-Fail-closed hooks are created only with `--fail-closed-hook`. Undo removes only the managed `.gitignore` line and deletes an init-created `.gitignore` only when it becomes empty.
+Undo with `opcore init --undo`; it removes only recorded setup artifacts where
+supported.
 
 ## Private Provider Mode
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,23 @@
 # Examples
 
+## First Run
+
+```bash
+npx @the-open-engine/opcore@0.1.0-alpha.0 init
+```
+
+Expected shape:
+
+```text
+Coverage:
+  files=... validation=... unsupported=...
+Findings:
+  <named finding>: count=... locations=...
+Setup:
+  approval=pending
+  writes=.opcore/config, agent guidance block, .gitignore line, .opcore/init-undo.json
+```
+
 ## Try The Loop
 
 ```bash
@@ -54,6 +72,9 @@ opcore init --repo . --approve --json
 ```
 
 The first command returns a plan. The approved command writes additive setup and undo metadata.
+Approved setup writes only `.opcore/config`, one delimited guidance block in an
+existing agent file or new `AGENTS.md`, a managed `.opcore/` line in
+`.gitignore` for Git repos, and `.opcore/init-undo.json`.
 
 ## Gate Changed Files
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,10 @@ npx @the-open-engine/opcore@0.1.0-alpha.0 init
 What this shows:
 
 - `npx @the-open-engine/opcore@0.1.0-alpha.0 init` starts the interactive onboarding wizard without a prior install.
-- The wizard runs a read-only scan first, prints Coverage before Findings, and asks before writing.
-- Approved init writes only additive `.opcore/config`, delimited agent guidance, undo metadata, a managed `.opcore/` `.gitignore` line in Git repos, and opt-in hooks when requested.
+- The wizard runs a read-only scan first, prints Coverage before Findings, reports concrete counts and locations, and asks before writing.
+- Scan/status/check/measure are read-only for source files.
+- Approved init writes only additive `.opcore/config`, one delimited guidance block in an existing agent file or new `AGENTS.md`, a managed `.opcore/` line in `.gitignore` for Git repos, and `.opcore/init-undo.json`.
+- Undo recorded setup with `opcore init --undo`.
 
 Alpha support is `darwin-arm64`, `darwin-x64`, and `linux-x64` with Node >=22. Unsupported platforms return typed degraded status instead of crashing. Windows is out of scope for `0.1.0-alpha.0`. Unsupported-language files are counted in coverage; day-one checks skip them.
 
@@ -31,7 +33,10 @@ export PATH="$(npm prefix -g)/bin:$PATH"
 
 Restart the shell or add that export to the shell startup file used by the environment.
 
-## First Scan
+## After Setup Reference
+
+Scan reads the repo and writes only `.opcore/report.json`,
+`.opcore/history.jsonl`, and bounded `.opcore/telemetry.jsonl`.
 
 Run this inside the repository you want to inspect:
 
@@ -48,7 +53,7 @@ opcore --json
 opcore status --json
 ```
 
-## Check Changes
+Check changed files from agents or hooks:
 
 ```bash
 opcore check --changed --json
@@ -59,7 +64,7 @@ Agents should treat any non-zero exit as a blocked write unless their workflow h
 
 `opcore check --changed --json` works in a freshly `git init` repo with no commits; it treats the empty baseline as the comparison base.
 
-## Measure Progress
+Measure progress from stored artifacts:
 
 ```bash
 opcore measure
@@ -68,7 +73,7 @@ opcore measure --repo .
 
 `opcore measure` compares the latest scan with the baseline or previous scan and reports concrete deltas such as type errors, untested surface, dead exports, suppression abuse, oversized files, and unsupported-language coverage.
 
-## Set Up Agent Guidance
+Approve setup non-interactively only when the plan is acceptable:
 
 ```bash
 opcore init
@@ -76,11 +81,11 @@ opcore init --approve
 opcore init --repo . --approve
 ```
 
-`opcore init` runs the read-only scan first, prints coverage before findings, shows the additive setup plan, and prompts on a TTY. `opcore init --json` previews without writing. Approved init may add `.opcore/config`, delimited agent guidance, mirrors for existing agent files, undo metadata, a managed `.opcore/` `.gitignore` line in Git repos, and optional hooks only when explicitly requested. Non-Git repos skip `.gitignore`; undo removes only the managed line. The `.opcore/` ignore covers `.opcore/telemetry.jsonl`. JSON output includes scan, language settings, interaction, and timing fields.
+`opcore init` runs the read-only scan first, prints coverage before findings, shows the additive setup plan, and prompts on a TTY. `opcore init --json` previews without writing. Approved init writes only the approved setup artifacts listed above. Non-Git repos skip `.gitignore`; undo removes only the managed line. The `.opcore/` ignore covers `.opcore/telemetry.jsonl`. JSON output includes scan, language settings, interaction, and timing fields.
 
 ## Coverage Honesty
 
-Opcore alpha is deep for TypeScript/JavaScript graph-backed signals and useful for Rust validation signals. Other languages are counted and reported as unsupported in v0; they do not get fake findings or fake scores.
+Opcore alpha is deep for TypeScript/JavaScript graph-backed signals and useful for Rust validation signals. Other languages are counted and reported as unsupported in v0; they do not get fake findings or fake ratings.
 
 ## Demo Loop
 

--- a/packages/opcore/README.md
+++ b/packages/opcore/README.md
@@ -2,7 +2,7 @@
 
 Deterministic local changed-file validation gate for coding agents.
 
-Opcore gives coding agents and maintainers a read-only-first repo check loop: scan the current repo, report coverage honestly, run changed-file validation, and track concrete local metric deltas. It is built for local feedback before review, not for remote publishing or opaque scoring.
+Opcore gives coding agents and maintainers a read-only-first repo check loop: scan the current repo, report coverage honestly, run changed-file validation, and track concrete local metric deltas. It is built for local feedback before review, not for remote publishing or opaque ratings.
 
 ## First Run
 
@@ -10,7 +10,9 @@ Opcore gives coding agents and maintainers a read-only-first repo check loop: sc
 npx @the-open-engine/opcore@0.1.0-alpha.0 init
 ```
 
-The one-command path starts the interactive onboarding wizard without a prior install. It runs a read-only scan first, prints Coverage before Findings, shows the additive setup plan, and asks before writing guidance, config, hooks, or ignore entries.
+The one-command path starts the interactive onboarding wizard without a prior install. It runs a read-only scan first, prints Coverage before Findings, reports concrete counts and locations, shows the additive setup plan, and asks before writing anything.
+
+Scan/status/check/measure are read-only for source files. The scan loop writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded `.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`, one delimited guidance block in an existing agent file or new `AGENTS.md`, a managed `.opcore/` line in `.gitignore` for Git repos, and `.opcore/init-undo.json`. Undo recorded setup with `opcore init --undo`.
 
 ## Changed-File Agent Gate
 
@@ -28,7 +30,7 @@ The command validates changed source files with stable JSON and agent-friendly e
 
 - TypeScript and JavaScript: deep graph-backed and validation signals for syntax, types, imports, relevant tests, dead exports, and graph structure when facts are available.
 - Rust: validation and toolchain signals only unless a later accepted issue expands graph extraction or product coverage.
-- Other languages: counted and reported as unsupported; Opcore does not invent findings or scores for files it cannot assess.
+- Other languages: counted and reported as unsupported; Opcore does not invent findings or ratings for files it cannot assess.
 
 Metric output is named evidence and deltas, not a blended quality number.
 
@@ -47,11 +49,11 @@ opcore measure --repo .
 opcore try
 ```
 
-- `opcore` scans read-only, prints Coverage before Findings, and writes only `.opcore/report.json` plus `.opcore/history.jsonl`.
+- `opcore` scans read-only, prints Coverage before Findings, and writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded `.opcore/telemetry.jsonl`.
 - `opcore status` reports activation readiness without running scans, installs, setup, checks, wrappers, or writes.
 - `opcore init` is scan-first and ask-before-write on a TTY; JSON preview runs stay plan-only unless approved.
 - `opcore check --changed --json` and `opcore check --staged --json` are agent gates for source changes.
-- `opcore measure` reads existing metric artifacts and reports named deltas, not a score.
+- `opcore measure` reads existing metric artifacts and reports named deltas, not a blended rating.
 - `opcore try` creates local sample repos and runs the demo loop without publishing anything.
 
 ## Repeat Use


### PR DESCRIPTION
Closes #5