### PR TITLE
docs(python): honest alpha Python coverage in launch and architecture docs (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,21 @@ content.
 
 ## Coverage honesty
 
-Opcore alpha is deep for TypeScript and JavaScript graph-backed validation.
-Rust coverage is validation and toolchain signal coverage only. Other
-languages are counted and reported unsupported instead of receiving fake
-findings.
+Opcore alpha is deep for TypeScript and JavaScript graph-backed validation:
+syntax, types, imports, relevant tests, dead exports, and graph structure when
+facts are available. Rust coverage is useful validation and toolchain signal
+coverage: source hygiene, oversized files, module evidence, cargo, fmt,
+clippy, rustdoc, and optional-tool evidence when available.
+
+Python is experimental and degraded-honest: graph-backed `.py`/`.pyi`
+structure, untested modules, dead exports, syntax, and source-hygiene signals.
+`python.types` depends on mypy or pyright and reports missing tools as
+degraded. Other non-TS/JS/Rust/Python languages are counted and reported
+unsupported instead of receiving fake findings.
 
 Reports use concrete counts, file paths, deltas, missing-tool notices, and
 degraded-check notices. Opcore does not collapse those signals into a single
-rating.
+rating or claim every-project Python coverage.
 
 ## Commands
 

--- a/docs/architecture/onboarding-command-shape-ard.md
+++ b/docs/architecture/onboarding-command-shape-ard.md
@@ -18,7 +18,7 @@ to a typed `required_missing` graph status, never crash.
 The onboarding UX must be honest and reversible: run a read-only scan first, show coverage
 before findings, propose additive repo setup, ask before writing, and write only approved
 files. EPIC #9 also requires onboarding to work in a freshly `git init`'d repo with no
-commits, across TS/JS, Rust, mixed, and unsupported (e.g. Python, counted not faked) stacks,
+commits, across TS/JS, Rust, Python, mixed, and unsupported (counted not faked) stacks,
 and to be proven on installed artifacts including the bin invoked outside `node_modules/.bin`.
 
 This ADR fixes the **command shape** so the implementation sub-issues (#40 wizard, #41 repo

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,11 +2,13 @@
 
 ## Coverage
 
-Opcore starts by counting the repository. TypeScript, JavaScript, Rust sources, `Cargo.toml`, and retained Rust metadata are recognized for alpha checks. Unsupported extensions are still counted with examples so reports do not imply broader coverage than exists.
+Opcore starts by counting the repository. TypeScript, JavaScript, Rust sources, `Cargo.toml`, retained Rust metadata, and Python `.py`/`.pyi` files are recognized for alpha checks. Unsupported extensions are still counted with examples so reports do not imply broader coverage than exists.
+
+Python coverage is experimental and degraded-honest. Graph-backed structure, untested modules, dead exports, syntax, source-hygiene, import graph, and relevant-test signals may be reported for `.py`/`.pyi` files. `python.types` depends on mypy or pyright; missing tools produce degraded optional-tool evidence instead of fake pass/fail findings.
 
 ## Findings
 
-Findings are named signals such as `typescript.type_errors`, `rust.source_hygiene`, and `coverage.unsupported_stacks`. Counts come from validation diagnostics, graph evidence when available, and repository census data. Opcore does not blend them into a single rating.
+Findings are named signals such as `typescript.type_errors`, `rust.source_hygiene`, `python.syntax`, `python.source-hygiene`, `python.types`, `python.import-graph`, `python.dead-code`, `python.relevant-tests`, and `coverage.unsupported_stacks`. Counts come from validation diagnostics, graph evidence when available, optional-tool degradation, and repository census data. Opcore does not blend them into a single rating.
 
 ## Artifacts
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -4,19 +4,21 @@
 
 ```text
 Coverage:
-  scenarios=4 files=12 validation=10 unsupported=1
+  scenarios=5 files=13 validation=9 unsupported=1
 Findings:
-  coverage.unsupported_stacks: count=1 delta=+0
-  rust.source_hygiene: count=4 delta=+0
-  typescript.type_errors: count=2 delta=+0
+  coverage.unsupported_stacks: count=1 delta=0
+  python.source_hygiene: count=1 delta=0
+  python.syntax_errors: count=1 delta=0
+  rust.source_hygiene: count=8 delta=0
+  typescript.type_errors: count=2 delta=0
 Loop:
   opcore --repo <sample>
   opcore init --repo <sample> --approve
-  opcore check --changed --checks typescript.syntax,typescript.types,rust.source-hygiene,rust.file-length --json
+  opcore check --changed --checks typescript.syntax,typescript.types,rust.source-hygiene,rust.file-length,python.syntax,python.source-hygiene --json
   opcore measure --repo <sample>
 Sandbox:
   <local temp directory>
   generated locally; published=false
 ```
 
-The JSON form returns `opcoreTry.published:false`, four scenario ids, command summaries, and named signals. The demo is generated on the local machine and keeps unsupported files visible instead of claiming day-one coverage for them.
+The JSON form returns `opcoreTry.published:false`, five scenario ids, command summaries, and named signals. The demo is generated on the local machine and keeps unsupported files visible instead of claiming day-one coverage for them.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,15 +28,17 @@ Expected shape:
 
 ```text
 Coverage:
-  scenarios=4 files=... validation=... unsupported=...
+  scenarios=5 files=13 validation=9 unsupported=1
 Findings:
-  coverage.unsupported_stacks: count=...
-  rust.source_hygiene: count=...
-  typescript.type_errors: count=...
+  coverage.unsupported_stacks: count=1 delta=0
+  python.source_hygiene: count=1 delta=0
+  python.syntax_errors: count=1 delta=0
+  rust.source_hygiene: count=8 delta=0
+  typescript.type_errors: count=2 delta=0
 Loop:
   opcore --repo <sample>
   opcore init --repo <sample> --approve
-  opcore check --changed --checks typescript.syntax,typescript.types,rust.source-hygiene,rust.file-length --json
+  opcore check --changed --checks typescript.syntax,typescript.types,rust.source-hygiene,rust.file-length,python.syntax,python.source-hygiene --json
   opcore measure --repo <sample>
 Sandbox:
   <local temp directory>
@@ -84,6 +86,14 @@ opcore check --changed --json
 
 The command defaults to `--base HEAD`; pass `--base origin/main` when the workflow needs a different comparison point.
 
+For Python-only validation in the same scan, check, measure loop:
+
+```bash
+opcore check --changed --checks python.syntax,python.source-hygiene --json
+```
+
+`python.types` is optional-tool evidence; missing mypy or pyright is reported as degraded instead of inventing a finding.
+
 ## Read Deltas
 
 ```bash
@@ -97,4 +107,6 @@ Coverage:
   files=... graph=... validation=... unsupported=...
 Signals:
   typescript.type_errors: 2 baseline=-1 previous=+0
+  python-measure-delta: python.dead-code previous=-1 baseline=+0
+  python.types: degraded requiredTool=mypy|pyright
 ```

--- a/docs/planning/opcore-alpha-roadmap.md
+++ b/docs/planning/opcore-alpha-roadmap.md
@@ -52,7 +52,7 @@ Opcore alpha must provide value quickly and honestly:
   `.opcore/history.jsonl`;
   bounded `.opcore/telemetry.jsonl` capped at 500 records or 1 MiB.
 - Init runs a read-only scan first, shows coverage before findings, then may write `.opcore/config`, AGENTS.md guidance, mirrors, undo metadata, and optional hooks only after explicit approval.
-- Reports must state coverage before findings: deep TypeScript/JavaScript graph support, Rust validation/toolchain support, and unsupported-language counts.
+- Reports must state coverage before findings: deep TypeScript/JavaScript graph support, Rust validation/toolchain support, experimental Python validation (degraded-honest), and unsupported-language counts.
 - Init JSON includes scan, per-language onboarding settings, interaction state, and timing fields for time-to-first-output checks.
 - Metrics are named, drillable counts and deltas, not a blended quality score.
 - Current Rox/CRG/CIX guardrails remain retained until explicit replacement evidence says otherwise.
@@ -68,9 +68,10 @@ Ship only signals the engine can defend:
 - Rust oversized files.
 - Rust module cycles, orphans, and unresolved module evidence.
 - Rust cargo, fmt, clippy, rustdoc, and optional-tool evidence when available, with honest degraded status when tools are missing.
+- Python `.py`/`.pyi` graph-backed structure, untested modules, dead exports, syntax, source-hygiene, import graph, relevant-test signals, and optional `python.types` via mypy or pyright with degraded status when tools are missing.
 - Unsupported language census with no fake findings.
 
-Do not ship headline claims for generic complexity, TS complexity, Python/Go/Java analysis, security, cross-repo percentiles, automatic fixes, or old-tool replacement.
+Do not ship headline claims for generic complexity, TS complexity, Python code analysis, Go/Java analysis, security, cross-repo percentiles, automatic fixes, or old-tool replacement.
 
 ## Release Gate
 
@@ -97,7 +98,7 @@ Do not call the alpha ready until current evidence proves:
 Use:
 
 - "Opcore is the robustness loop for agent-era repos."
-- "Deep for TypeScript/JavaScript and useful for Rust in alpha; unsupported stacks are counted and reported honestly."
+- "Deep for TypeScript/JavaScript, useful for Rust, and experimental Python validation (degraded-honest) in alpha; unsupported stacks are counted and reported honestly."
 - "ASP is an optional private host/provider seam until the protocol has independent interoperability evidence."
 
 Avoid:
@@ -106,6 +107,7 @@ Avoid:
 - "Opcore proves the standard."
 - "Opcore replaces Rox/CRG/CIX."
 - "Works with every stack."
+- "Python code analysis" as a headline.
 - "Detects AI authorship."
 - "Security scanner" or "SAST."
 - "Automatically fixes your repo."

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ What this shows:
 - Approved init writes only additive `.opcore/config`, one delimited guidance block in an existing agent file or new `AGENTS.md`, a managed `.opcore/` line in `.gitignore` for Git repos, and `.opcore/init-undo.json`.
 - Undo recorded setup with `opcore init --undo`.
 
-Alpha support is `darwin-arm64`, `darwin-x64`, and `linux-x64` with Node >=22. Unsupported platforms return typed degraded status instead of crashing. Windows is out of scope for `0.1.0-alpha.0`. Unsupported-language files are counted in coverage; day-one checks skip them.
+Alpha support is `darwin-arm64`, `darwin-x64`, and `linux-x64` with Node >=22. Unsupported platforms return typed degraded status instead of crashing. Windows is out of scope for `0.1.0-alpha.0`. Language coverage is deep for TypeScript/JavaScript, useful for Rust, and experimental degraded-honest for Python. Other non-TS/JS/Rust/Python files are counted in coverage; day-one checks skip them.
 
 ## Repeat Use
 
@@ -58,6 +58,7 @@ Check changed files from agents or hooks:
 ```bash
 opcore check --changed --json
 opcore check --staged --json
+opcore check --changed --checks python.syntax,python.source-hygiene --json
 ```
 
 Agents should treat any non-zero exit as a blocked write unless their workflow has a typed recovery path.
@@ -71,7 +72,7 @@ opcore measure
 opcore measure --repo .
 ```
 
-`opcore measure` compares the latest scan with the baseline or previous scan and reports concrete deltas such as type errors, untested surface, dead exports, suppression abuse, oversized files, and unsupported-language coverage.
+`opcore measure` compares the latest scan with the baseline or previous scan and reports concrete deltas such as type errors, untested surface, dead exports, Python syntax/source-hygiene or optional type-tool degradation, suppression abuse, oversized files, and unsupported-language coverage.
 
 Approve setup non-interactively only when the plan is acceptable:
 
@@ -85,7 +86,7 @@ opcore init --repo . --approve
 
 ## Coverage Honesty
 
-Opcore alpha is deep for TypeScript/JavaScript graph-backed signals and useful for Rust validation signals. Other languages are counted and reported as unsupported in v0; they do not get fake findings or fake ratings.
+Opcore alpha is deep for TypeScript/JavaScript graph-backed signals and useful for Rust validation signals. Python is experimental and degraded-honest: `.py`/`.pyi` graph-backed structure, untested modules, dead exports, syntax, and source-hygiene are reported when available; `python.types` depends on mypy or pyright and reports missing tools as degraded. Other non-TS/JS/Rust/Python languages are counted and reported as unsupported; they do not get fake findings or fake ratings.
 
 ## Demo Loop
 

--- a/packages/opcore/README.md
+++ b/packages/opcore/README.md
@@ -29,8 +29,9 @@ The command validates changed source files with stable JSON and agent-friendly e
 ## Coverage Honesty
 
 - TypeScript and JavaScript: deep graph-backed and validation signals for syntax, types, imports, relevant tests, dead exports, and graph structure when facts are available.
-- Rust: validation and toolchain signals only unless a later accepted issue expands graph extraction or product coverage.
-- Other languages: counted and reported as unsupported; Opcore does not invent findings or ratings for files it cannot assess.
+- Rust: useful validation and toolchain signals for source hygiene, oversized files, module evidence, cargo, fmt, clippy, rustdoc, and optional-tool evidence when available.
+- Python: experimental degraded-honest validation for graph-backed `.py`/`.pyi` structure, untested modules, dead exports, syntax, and source-hygiene; `python.types` depends on mypy or pyright and reports missing tools as degraded.
+- Other non-TS/JS/Rust/Python languages: counted and reported as unsupported; Opcore does not invent findings or ratings for files it cannot assess.
 
 Metric output is named evidence and deltas, not a blended quality number.
 


### PR DESCRIPTION
Completes #24 (honest Python coverage docs). Python is alpha-supported (experimental, degraded-honest), so launch + architecture docs now describe deep TS/JS, useful Rust, and experimental degraded-honest Python tiers, keeping the no-Python-code-analysis-headline rule.

- README / packages/opcore/README / quickstart / concepts / examples / roadmap: experimental degraded-honest Python tier; both install forms and required tokens preserved.
- docs/demo.md: corrected to the real `opcore try` output (scenarios=5 with `python.source_hygiene` and `python.syntax_errors`).
- docs/architecture/onboarding-command-shape-ard.md: removed the stale "Python, counted not faked" unsupported claim (Python is now a supported stack).

No source, scripts, tests, or gate files changed; docs-only. release:hygiene, workspace, and provenance verified locally.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_017zndZBdg5KD31UHdJYQRwc