### PR TITLE
fix: build covibes graph without sidecar buffer failures

### DIFF
--- a/crates/graph-core/src/extraction/discovery.rs
+++ b/crates/graph-core/src/extraction/discovery.rs
@@ -68,6 +68,7 @@ struct SourceDiscovery<'a> {
     sources: Vec<DiscoveredSource>,
     diagnostics: Vec<GraphExtractionDiagnostic>,
     depth_reported: bool,
+    files_reported: bool,
 }
 
 impl<'a> SourceDiscovery<'a> {
@@ -89,6 +90,7 @@ impl<'a> SourceDiscovery<'a> {
             sources: Vec::new(),
             diagnostics: Vec::new(),
             depth_reported: false,
+            files_reported: false,
         })
     }
 
@@ -163,15 +165,18 @@ impl<'a> SourceDiscovery<'a> {
 
     fn push_source(&mut self, entry: &DirEntry, relative_path: String, language: SourceLanguage) {
         if self.sources.len() >= self.options.max_files {
-            self.diagnostics.push(error(
-                GraphExtractionDiagnosticCategory::MaxFilesExceeded,
-                format!(
-                    "source discovery exceeded maxFiles {}",
-                    self.options.max_files
-                ),
-                Some(relative_path),
-                Some(language.as_str().to_string()),
-            ));
+            if !self.files_reported {
+                self.diagnostics.push(error(
+                    GraphExtractionDiagnosticCategory::MaxFilesExceeded,
+                    format!(
+                        "source discovery exceeded maxFiles {}",
+                        self.options.max_files
+                    ),
+                    Some(relative_path),
+                    Some(language.as_str().to_string()),
+                ));
+                self.files_reported = true;
+            }
             return;
         }
         match std::fs::read(entry.path()) {

--- a/crates/graph-core/src/extraction/mod.rs
+++ b/crates/graph-core/src/extraction/mod.rs
@@ -24,7 +24,7 @@ pub use discovery::{
 pub use facts::FileFacts;
 pub use language::SourceLanguage;
 
-pub const DEFAULT_MAX_FILES: usize = 4_000;
+pub const DEFAULT_MAX_FILES: usize = usize::MAX;
 pub const DEFAULT_MAX_DEPTH: usize = 64;
 pub const EXTRACTION_GENERATED_AT: &str = "2026-06-04T00:00:00.000Z";
 

--- a/crates/graph-core/src/extraction/parser.rs
+++ b/crates/graph-core/src/extraction/parser.rs
@@ -53,17 +53,20 @@ fn parse_oxc<'a>(
         Err(diagnostic) => return ParsedSource::from(diagnostic),
     };
     let parsed = Parser::new(allocator, source_text, source_type).parse();
-    if parser_failed(&parsed) {
-        return diagnostic_result(
-            source,
+    let diagnostics = if !parsed.panicked && parsed.errors.is_empty() {
+        Vec::new()
+    } else {
+        vec![warning(
             GraphExtractionDiagnosticCategory::ParseError,
             parser_error_message(&parsed, source_text),
-        );
-    }
+            Some(source.relative_path.clone()),
+            Some(source.language.as_str().to_string()),
+        )]
+    };
 
     ParsedSource {
         program: Some(ParsedProgram::Oxc(parsed.program)),
-        diagnostics: Vec::new(),
+        diagnostics,
     }
 }
 
@@ -147,10 +150,6 @@ fn source_type_for_source(
             Some(source.language.as_str().to_string()),
         )
     })
-}
-
-fn parser_failed(parsed: &ParserReturn<'_>) -> bool {
-    parsed.panicked || !parsed.errors.is_empty()
 }
 
 fn parser_error_message(parsed: &ParserReturn<'_>, source_text: &str) -> String {

--- a/crates/graph-core/src/extraction/tests.rs
+++ b/crates/graph-core/src/extraction/tests.rs
@@ -608,13 +608,37 @@ fn source_re_export_alias_imports_resolve_to_source_exported_symbols() -> TestRe
 }
 
 #[test]
-fn parse_errors_are_typed_and_block_empty_success() -> TestResult {
+fn oxc_parse_errors_are_typed_warnings_and_non_fatal() -> TestResult {
     let repo = repo_with_tsconfig()?;
     write(&repo, "src/broken.ts", "export function broken(")?;
-    assert_error_category(
-        extract_sources(ExtractionOptions::new(repo.path())),
-        Category::ParseError,
+    write(
+        &repo,
+        "src/valid.ts",
+        "export function valid() { return 1; }",
+    )?;
+
+    let result = extract_sources(ExtractionOptions::new(repo.path()));
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.category == Category::ParseError
+                && diagnostic.severity == Severity::Warning),
+        "{:?}",
+        result.diagnostics
     );
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.category == Category::ParseError
+                && diagnostic.severity == Severity::Error),
+        "{:?}",
+        result.diagnostics
+    );
+    required_attributes(&result.nodes, "file:src/broken.ts")?;
+    required_attributes(&result.nodes, "function:src/valid.ts#valid")?;
     Ok(())
 }
 
@@ -669,6 +693,31 @@ fn max_file_errors_are_typed_and_block_empty_success() -> TestResult {
     let mut options = ExtractionOptions::new(repo.path());
     options.max_files = 0;
     assert_error_category(extract_sources(options), Category::MaxFilesExceeded);
+    Ok(())
+}
+
+#[test]
+fn default_discovery_has_no_legacy_four_thousand_file_ceiling() -> TestResult {
+    let repo = repo_with_tsconfig()?;
+    for index in 0..4_001 {
+        write(
+            &repo,
+            &format!("src/generated/file_{index:04}.ts"),
+            "export const value = 1;\n",
+        )?;
+    }
+
+    let discovery = discover_sources_for_options(&ExtractionOptions::new(repo.path()));
+
+    assert_eq!(discovery.sources.len(), 4_001);
+    assert!(
+        !discovery
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.category == Category::MaxFilesExceeded),
+        "{:?}",
+        discovery.diagnostics
+    );
     Ok(())
 }
 

--- a/packages/graph/src/node-shims.d.ts
+++ b/packages/graph/src/node-shims.d.ts
@@ -24,7 +24,7 @@ declare module "node:child_process" {
       cwd?: string;
       encoding?: string;
       input?: string;
-      stdio?: readonly string[];
+      stdio?: readonly (string | number)[];
       timeout?: number;
     }
   ): SpawnSyncReturns;
@@ -60,9 +60,17 @@ declare module "node:crypto" {
 }
 
 declare module "node:fs" {
+  export function closeSync(fd: number): void;
   export function existsSync(path: string): boolean;
+  export function mkdtempSync(prefix: string): string;
+  export function openSync(path: string, flags: string): number;
   export function readFileSync(path: string): Uint8Array;
   export function readFileSync(path: string, encoding: "utf8"): string;
+  export function rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void;
+}
+
+declare module "node:os" {
+  export function tmpdir(): string;
 }
 
 declare module "node:module" {

--- a/packages/graph/src/sidecar.ts
+++ b/packages/graph/src/sidecar.ts
@@ -9,10 +9,15 @@ import type {
 } from "@the-open-engine/opcore-contracts";
 import { validateGraphDaemonResponse, validateGraphWatchLifecycle } from "@the-open-engine/opcore-contracts";
 import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ResolvedGraphCoreArtifact } from "./artifact.js";
 import { providerFailureStatus, resolveGraphCoreArtifact, schemaMismatchStatus } from "./artifact.js";
+
+const GRAPH_CORE_PIPELINE_TIMEOUT_MS = 120_000;
+const GRAPH_CORE_QUERY_TIMEOUT_MS = 30_000;
+const GRAPH_CORE_WATCH_ONCE_TIMEOUT_MS = 120_000;
 
 declare const process: {
   kill(pid: number, signal?: 0): boolean;
@@ -21,13 +26,20 @@ declare const process: {
 export function invokeGraphCoreSidecar(request: GraphDaemonRequest): GraphDaemonResponse {
   const resolution = resolveGraphCoreArtifact();
   if (!resolution.ok) return failureResponse(request, resolution.status);
-  if (request.operation === "watch") return invokeGraphCoreWatch(resolution.artifact, request);
-  const result = spawnGraphCoreSidecar(resolution.artifact.executablePath, request);
+  return invokeResolvedGraphCoreSidecar(resolution.artifact, request);
+}
+
+export function invokeResolvedGraphCoreSidecar(
+  artifact: ResolvedGraphCoreArtifact,
+  request: GraphDaemonRequest
+): GraphDaemonResponse {
+  if (request.operation === "watch") return invokeGraphCoreWatch(artifact, request);
+  const result = spawnGraphCoreSidecar(artifact.executablePath, request);
   const status = processFailureStatus(result);
   if (status) return failureResponse(request, status);
   const line = firstStdoutLine(result.stdout);
   if (!line) return failureResponse(request, noStdoutStatus());
-  return decodeSidecarResponse(request, line, resolution.artifact);
+  return decodeSidecarResponse(request, line, artifact);
 }
 
 function invokeGraphCoreWatch(
@@ -48,10 +60,8 @@ function invokeGraphCoreWatch(
 
   const args = watchArgs(request, repoRoot);
   if (request.once) {
-    const result = spawnSync(resolution.artifact.executablePath, args, {
-      encoding: "utf8",
-      timeout: 10000,
-      stdio: ["ignore", "pipe", "pipe"]
+    const result = spawnGraphCoreSidecarProcess(resolution.artifact.executablePath, args, {
+      timeoutMs: GRAPH_CORE_WATCH_ONCE_TIMEOUT_MS
     });
     const status = processFailureStatus(result);
     if (status) return failureResponse(request, status);
@@ -114,12 +124,51 @@ function invokeGraphCoreWatch(
 }
 
 function spawnGraphCoreSidecar(executablePath: string, request: GraphDaemonRequest): SpawnSyncReturns {
-  return spawnSync(executablePath, [], {
+  return spawnGraphCoreSidecarProcess(executablePath, [], {
     input: `${JSON.stringify(request)}\n`,
-    encoding: "utf8",
-    timeout: 5000,
-    stdio: ["pipe", "pipe", "pipe"]
+    timeoutMs: sidecarRequestTimeoutMs(request)
   });
+}
+
+function sidecarRequestTimeoutMs(request: GraphDaemonRequest): number {
+  if (request.operation === "build" || request.operation === "update") return GRAPH_CORE_PIPELINE_TIMEOUT_MS;
+  return GRAPH_CORE_QUERY_TIMEOUT_MS;
+}
+
+function spawnGraphCoreSidecarProcess(
+  executablePath: string,
+  args: readonly string[],
+  options: { input?: string; timeoutMs: number }
+): SpawnSyncReturns {
+  const tempDir = mkdtempSync(join(tmpdir(), "opcore-graph-sidecar-"));
+  const stdoutPath = join(tempDir, "stdout.jsonl");
+  const stderrPath = join(tempDir, "stderr.log");
+  let stdoutFd: number | undefined;
+  let stderrFd: number | undefined;
+  try {
+    stdoutFd = openSync(stdoutPath, "w+");
+    stderrFd = openSync(stderrPath, "w+");
+    const stdin = options.input === undefined ? "ignore" : "pipe";
+    const result = spawnSync(executablePath, args, {
+      input: options.input,
+      encoding: "utf8",
+      timeout: options.timeoutMs,
+      stdio: [stdin, stdoutFd, stderrFd]
+    });
+    closeSync(stdoutFd);
+    stdoutFd = undefined;
+    closeSync(stderrFd);
+    stderrFd = undefined;
+    return {
+      ...result,
+      stdout: readFileSync(stdoutPath, "utf8"),
+      stderr: readFileSync(stderrPath, "utf8")
+    };
+  } finally {
+    if (stdoutFd !== undefined) closeSync(stdoutFd);
+    if (stderrFd !== undefined) closeSync(stderrFd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 }
 
 function watchArgs(request: GraphDaemonRequest, repoRoot: string): string[] {

--- a/packages/opcore-graph-core-darwin-arm64/metadata.json
+++ b/packages/opcore-graph-core-darwin-arm64/metadata.json
@@ -4,6 +4,6 @@
   "targetPlatform": "darwin-arm64",
   "binaryPath": "opcore-graph-core",
   "checksumPath": "opcore-graph-core.sha256",
-  "checksumSha256": "3e3d2fbb75292c9557ebcb8a81912c053b6c241334f7b7882dc68b1c7ba3739a",
+  "checksumSha256": "f08fa2afab6c6ff6221cfd5ad4fc5cd25ad744fa64773d46fe53f926c4493272",
   "buildProfile": "release"
 }

--- a/packages/opcore-graph-core-darwin-arm64/opcore-graph-core.sha256
+++ b/packages/opcore-graph-core-darwin-arm64/opcore-graph-core.sha256
@@ -1,1 +1,1 @@
-3e3d2fbb75292c9557ebcb8a81912c053b6c241334f7b7882dc68b1c7ba3739a  opcore-graph-core
+f08fa2afab6c6ff6221cfd5ad4fc5cd25ad744fa64773d46fe53f926c4493272  opcore-graph-core

--- a/packages/validation-rust/src/function-metrics-check.ts
+++ b/packages/validation-rust/src/function-metrics-check.ts
@@ -216,13 +216,13 @@ function functionMetricLines(item: FunctionMetricNode): number {
 
 function functionMetricComplexity(item: FunctionMetricNode): number {
   return numeric(
-    item.metrics?.cyclomatic?.sum,
-    numeric(item.metrics?.cyclomatic?.max, numeric(item.metrics?.cyclomatic?.total, numeric(item.cyclomatic_complexity, numeric(item.complexity, 1))))
+    item.metrics?.cyclomatic?.max,
+    numeric(item.metrics?.cyclomatic?.sum, numeric(item.metrics?.cyclomatic?.total, numeric(item.cyclomatic_complexity, numeric(item.complexity, 1))))
   );
 }
 
 function functionMetricParams(item: FunctionMetricNode): number {
-  return numeric(item.metrics?.nargs?.total, numeric(item.metrics?.nargs?.functions_max, numeric(item.metrics?.nargs?.max, paramCount(item))));
+  return numeric(item.metrics?.nargs?.functions_max, numeric(item.metrics?.nargs?.max, numeric(item.metrics?.nargs?.total, paramCount(item))));
 }
 
 function parseFunctionMetricJson(stdout: string): unknown {
@@ -243,8 +243,8 @@ function unitPath(
   return undefined;
 }
 
-function isFunctionMetricNode(item: { kind?: unknown; metrics?: unknown; name?: unknown; start_line?: unknown; end_line?: unknown }): boolean {
-  return item.kind === "function" || (typeof item.name === "string" && item.metrics !== undefined && item.start_line !== undefined && item.end_line !== undefined);
+function isFunctionMetricNode(item: { kind?: unknown }): boolean {
+  return item.kind === "function";
 }
 
 function numeric(value: unknown, fallback: number): number {

--- a/tests/graph-pipeline-cli.test.mjs
+++ b/tests/graph-pipeline-cli.test.mjs
@@ -256,7 +256,7 @@ describe("graph pipeline CLI", () => {
   it("fails non-once watch startup when initial extraction fails", () => {
     const temp = mkdtempSync(join(tmpdir(), "lattice-watch-startup-fail-"));
     try {
-      writeFileSync(join(temp, "bad.ts"), "export const broken = ;\n");
+      writeFileSync(join(temp, "bad.rs"), "pub fn broken( {\n");
 
       const watch = run(latticeBin, ["graph", "watch", "--repo", temp, "--poll-interval-ms", "50", "--json"], 1);
       assert.equal(watch.status, "error");

--- a/tests/graph-sidecar-transport.test.mjs
+++ b/tests/graph-sidecar-transport.test.mjs
@@ -1,0 +1,143 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { invokeResolvedGraphCoreSidecar } from "../packages/graph/dist/sidecar.js";
+
+const currentTarget = `${process.platform}-${process.arch}`;
+
+describe("graph sidecar transport", () => {
+  it("decodes sidecar responses larger than the default spawnSync buffer", () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-graph-sidecar-large-"));
+    try {
+      const largeChangedFiles = Array.from({ length: 22000 }, (_, index) => {
+        return `src/generated/module-${String(index).padStart(5, "0")}/component-${String(index).padStart(5, "0")}.ts`;
+      });
+      const responsePath = join(temp, "response.jsonl");
+      const executablePath = join(temp, "opcore-graph-core");
+      writeFileSync(responsePath, `${JSON.stringify(buildResponse(temp, largeChangedFiles, "large-build"))}\n`);
+      assert.ok(readFileSync(responsePath, "utf8").length > 1024 * 1024);
+      writeSidecarStub(executablePath, [
+        `process.stdout.write(require("node:fs").readFileSync(${JSON.stringify(responsePath)}, "utf8"));`
+      ]);
+
+      const result = invokeResolvedGraphCoreSidecar(testArtifact(temp, executablePath), {
+        protocol: "opcore.graph.daemon",
+        requestId: "large-build",
+        schemaVersion: 1,
+        operation: "build",
+        repo: {
+          repoRoot: temp
+        }
+      });
+
+      assert.equal(result.status.state, "available");
+      assert.equal(result.pipeline.summary.changedFiles.length, largeChangedFiles.length);
+      assert.equal(result.pipeline.summary.changedFiles.at(-1), largeChangedFiles.at(-1));
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it("allows pipeline sidecars to run longer than the legacy five second timeout", { timeout: 15000 }, () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-graph-sidecar-timeout-"));
+    try {
+      const responsePath = join(temp, "response.jsonl");
+      const executablePath = join(temp, "opcore-graph-core");
+      writeFileSync(responsePath, `${JSON.stringify(buildResponse(temp, ["src/app.ts"], "slow-build"))}\n`);
+      writeSidecarStub(executablePath, [
+        "setTimeout(() => {",
+        `  process.stdout.write(require("node:fs").readFileSync(${JSON.stringify(responsePath)}, "utf8"));`,
+        "}, 5500);"
+      ]);
+
+      const result = invokeResolvedGraphCoreSidecar(testArtifact(temp, executablePath), {
+        protocol: "opcore.graph.daemon",
+        requestId: "slow-build",
+        schemaVersion: 1,
+        operation: "build",
+        repo: {
+          repoRoot: temp
+        }
+      });
+
+      assert.equal(result.status.state, "available");
+      assert.deepEqual(result.pipeline.summary.changedFiles, ["src/app.ts"]);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+});
+
+function writeSidecarStub(executablePath, bodyLines) {
+  writeFileSync(executablePath, ["#!/usr/bin/env node", ...bodyLines].join("\n"));
+  chmodSync(executablePath, 0o755);
+}
+
+function availableStatus(repoRoot) {
+  return {
+    state: "available",
+    mode: "required",
+    provider: "opcore-graph",
+    schemaVersion: 1,
+    repo: { repoRoot },
+    freshness: {
+      generatedAt: "2026-01-01T00:00:01.000Z",
+      ageMs: 0,
+      stale: false
+    },
+    nodes_by_kind: {},
+    edges_by_kind: {}
+  };
+}
+
+function buildResponse(repoRoot, changedFiles, requestId) {
+  return {
+    protocol: "opcore.graph.daemon",
+    requestId,
+    schemaVersion: 1,
+    status: availableStatus(repoRoot),
+    pipeline: {
+      summary: {
+        operation: "build",
+        repo: { repoRoot },
+        storePath: join(repoRoot, ".lattice", "graph", "graph.db"),
+        startedAt: "2026-01-01T00:00:00.000Z",
+        completedAt: "2026-01-01T00:00:01.000Z",
+        durationMs: 1000,
+        discoveredFiles: changedFiles.length,
+        parsedFiles: changedFiles.length,
+        changedFiles,
+        deletedFiles: [],
+        unchangedFiles: 0,
+        fullRebuildRequired: false,
+        diagnosticsCount: 0,
+        phaseTimings: [
+          {
+            phase: "discovery",
+            startedAt: "2026-01-01T00:00:00.000Z",
+            completedAt: "2026-01-01T00:00:01.000Z",
+            durationMs: 1000,
+            fileCount: changedFiles.length
+          }
+        ]
+      },
+      status: availableStatus(repoRoot)
+    }
+  };
+}
+
+function testArtifact(temp, executablePath) {
+  return {
+    artifactName: "opcore-graph-core",
+    artifactVersion: "0.1.0-alpha.0",
+    targetPlatform: currentTarget,
+    binaryPath: "opcore-graph-core",
+    checksumPath: "opcore-graph-core.sha256",
+    checksumSha256: "test-checksum",
+    buildProfile: "test",
+    executablePath,
+    metadataPath: join(temp, "metadata.json")
+  };
+}

--- a/tests/validation-rust.test.mjs
+++ b/tests/validation-rust.test.mjs
@@ -1420,15 +1420,34 @@ const rustCheckIds = [
             {
               kind: "unit",
               name: "crates/app/src/lib.rs",
+              start_line: 1,
+              end_line: 200,
+              metrics: {
+                cyclomatic: { sum: 200 },
+                nargs: { total: 50 },
+                loc: { sloc: 200 }
+              },
               spaces: [
+                {
+                  kind: "impl",
+                  name: "Thing",
+                  start_line: 1,
+                  end_line: 120,
+                  metrics: {
+                    cyclomatic: { sum: 120 },
+                    nargs: { total: 20 },
+                    loc: { sloc: 120 }
+                  },
+                  spaces: []
+                },
                 {
                   kind: "function",
                   name: "too_much",
                   start_line: 1,
                   end_line: 9,
                   metrics: {
-                    cyclomatic: { sum: 7 },
-                    nargs: { total: 5 },
+                    cyclomatic: { max: 7 },
+                    nargs: { functions_max: 5 },
                     loc: { sloc: 9 }
                   }
                 }


### PR DESCRIPTION
Fix `opcore graph build --repo <covibes> --json` failing with `spawnSync ... ENOBUFS` while canonical CRG succeeds.

Problem:
- The TypeScript graph sidecar wrapper used `spawnSync` pipe buffers for graph-core JSON responses, so large build responses exceeded Node's default buffer.
- Covibes also exposed two follow-on root causes: the graph default file cap stopped at 4000 files, and OXC parse errors blocked the whole graph build where current CRG continues.
- Opcore Rust function metrics treated `rust-code-analysis-cli` aggregate `unit`/`impl` rows as functions; Rox does not report those rows as function findings.

Approach:
- Spool graph-core stdout/stderr through temporary files and use operation-appropriate sidecar timeouts.
- Remove the legacy default max-file ceiling while preserving explicit `maxFiles` diagnostics.
- Keep OXC parse errors as typed warnings with partial graph facts; Rust parse errors still fail closed.
- Restrict Rust function metrics to actual `kind: "function"` rows from `rust-code-analysis-cli`.

Verification:
- `cargo fmt --check`
- `cargo test -p opcore-graph-core --locked`
- `npm run build`
- `node --test tests/graph-sidecar-transport.test.mjs tests/graph-pipeline-cli.test.mjs tests/graph-core-artifact.test.mjs`
- `node --test tests/validation-rust.test.mjs`
- `npm run current-tools:validate-changed`
- `npm run current-tools:validate-rust-graph`
- `npm run ci`
- Covibes comparison on `/Users/tom/code/covibes/covibes`: CRG build passed in 26.64s; Opcore graph build passed in 8.02s with 7993 parsed files.

Non-goals:
- Does not add a daemon.
- Does not address unpublished package install issues.
