### PR TITLE
docs: clarify alpha source install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ agents. It starts with read-only repository scans, reports honest coverage
 before findings, and gives command-running agents a JSON gate for edits before
 they land.
 
-## First Run
+## First Run From This Checkout
 
-Run the onboarding wizard from an existing repository:
+Package publication is maintainer-controlled during alpha staging. Until
+maintainers publish the alpha packages, run Opcore from a source checkout:
 
 ```bash
-npx @the-open-engine/opcore@0.1.0-alpha.0 init
+npm ci
+npm run build
+node packages/opcore/dist/index.js init --repo /path/to/repo
 ```
 
 `opcore init` detects supported stacks, runs a read-only first scan, prints
@@ -32,7 +35,13 @@ managed `.opcore/` `.gitignore` line for Git repos, and
 Agents and hooks should use the JSON contract `opcore check --changed --json`;
 humans do not need to learn that gate before onboarding.
 
-Install globally for repeat use:
+After package publication, the one-command first-run path is:
+
+```bash
+npx @the-open-engine/opcore@0.1.0-alpha.0 init
+```
+
+After package publication, install globally for repeat use:
 
 ```bash
 npm install -g @the-open-engine/opcore@0.1.0-alpha.0
@@ -134,9 +143,12 @@ at @docs/architecture/runtime-cli-ard.md.
 
 ## ASP provider: providers assess, hosts decide
 
-`opcore-asp-provider --stdio` launches the ASP provider facade. The provider
-returns assessments and degraded coverage details; ASP hosts own workspace
-grants, policy, decisions, receipts, and apply behavior.
+The aggregate `@the-open-engine/opcore` package exposes only the `opcore` bin.
+`opcore-asp-provider --stdio` is provided by the separate
+`@the-open-engine/opcore-asp-provider` package, or by
+`node packages/asp-provider/dist/index.js --stdio` from a built source checkout.
+The provider returns assessments and degraded coverage details; ASP hosts own
+workspace grants, policy, decisions, receipts, and apply behavior.
 
 Provider output is assessment evidence, not a host decision.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,7 +3,7 @@
 ## First Run
 
 ```bash
-npx @the-open-engine/opcore@0.1.0-alpha.0 init
+node packages/opcore/dist/index.js init --repo /path/to/repo
 ```
 
 Expected shape:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,12 +1,20 @@
 # Quickstart
 
+## From This Checkout
+
+Package publication is maintainer-controlled during alpha staging. Until
+maintainers publish the alpha packages, run Opcore from a source checkout:
+
 ```bash
-npx @the-open-engine/opcore@0.1.0-alpha.0 init
+npm ci
+npm run build
+node packages/opcore/dist/index.js init --repo /path/to/repo
 ```
 
 What this shows:
 
-- `npx @the-open-engine/opcore@0.1.0-alpha.0 init` starts the interactive onboarding wizard without a prior install.
+- The built source command starts the interactive onboarding wizard without
+  relying on npm registry publication.
 - The wizard runs a read-only scan first, prints Coverage before Findings, reports concrete counts and locations, and asks before writing.
 - Scan/status/check/measure are read-only for source files.
 - Approved init writes only additive `.opcore/config`, one delimited guidance block in an existing agent file or new `AGENTS.md`, a managed `.opcore/` line in `.gitignore` for Git repos, and `.opcore/init-undo.json`.
@@ -14,9 +22,15 @@ What this shows:
 
 Alpha support is `darwin-arm64`, `darwin-x64`, and `linux-x64` with Node >=22. Unsupported platforms return typed degraded status instead of crashing. Windows is out of scope for `0.1.0-alpha.0`. Language coverage is deep for TypeScript/JavaScript, useful for Rust, and experimental degraded-honest for Python. Other non-TS/JS/Rust/Python files are counted in coverage; day-one checks skip them.
 
-## Repeat Use
+## Package Publication
 
-Install globally when you expect to run Opcore repeatedly:
+After package publication, the one-command first-run path is:
+
+```bash
+npx @the-open-engine/opcore@0.1.0-alpha.0 init
+```
+
+After package publication, install globally when you expect to run Opcore repeatedly:
 
 ```bash
 npm install -g @the-open-engine/opcore@0.1.0-alpha.0
@@ -103,5 +117,10 @@ Private ASP hosts may launch the provider process behind host-owned decisions an
 ```bash
 opcore-asp-provider --stdio
 ```
+
+The aggregate `@the-open-engine/opcore` package exposes only `opcore`;
+`opcore-asp-provider` comes from the separate
+`@the-open-engine/opcore-asp-provider` package. From a built source checkout,
+use `node packages/asp-provider/dist/index.js --stdio`.
 
 Do not treat provider output as a gate decision. The provider returns ASP Assessments; the ASP host returns allow, deny, or indeterminate decisions plus receipts.

--- a/packages/asp-provider/README.md
+++ b/packages/asp-provider/README.md
@@ -25,13 +25,16 @@ and honest coverage; the ASP host owns the allow/deny/transaction outcome.
 
 ## Install
 
+Package publication is maintainer-controlled during alpha staging. After
+publication, install the provider package directly:
+
 ```sh
 npm install @the-open-engine/opcore-asp-provider
 ```
 
 This installs the `opcore-asp-provider` bin alongside its Opcore validation
 dependencies. The package is launched by an ASP host/manager, not run directly by an
-end user. A provisional install manifest is published at
+end user. A provisional install manifest is included at
 `@the-open-engine/opcore-asp-provider/manifests/opcore-asp-provider.provisional.json`
 (see [Provisional manifest](#provisional-manifest)).
 
@@ -39,6 +42,12 @@ end user. A provisional install manifest is published at
 
 ```sh
 opcore-asp-provider --stdio
+```
+
+From a built source checkout, launch the same provider entrypoint with:
+
+```sh
+node packages/asp-provider/dist/index.js --stdio
 ```
 
 The process speaks newline-delimited JSON-RPC 2.0 over stdin/stdout. Without

--- a/packages/opcore/README.md
+++ b/packages/opcore/README.md
@@ -4,13 +4,18 @@ Deterministic local changed-file validation gate for coding agents.
 
 Opcore gives coding agents and maintainers a read-only-first repo check loop: scan the current repo, report coverage honestly, run changed-file validation, and track concrete local metric deltas. It is built for local feedback before review, not for remote publishing or opaque ratings.
 
-## First Run
+## First Run From This Checkout
+
+Package publication is maintainer-controlled during alpha staging. Until
+maintainers publish the alpha packages, run Opcore from a source checkout:
 
 ```bash
-npx @the-open-engine/opcore@0.1.0-alpha.0 init
+npm ci
+npm run build
+node packages/opcore/dist/index.js init --repo /path/to/repo
 ```
 
-The one-command path starts the interactive onboarding wizard without a prior install. It runs a read-only scan first, prints Coverage before Findings, reports concrete counts and locations, shows the additive setup plan, and asks before writing anything.
+The command starts the interactive onboarding wizard. It runs a read-only scan first, prints Coverage before Findings, reports concrete counts and locations, shows the additive setup plan, and asks before writing anything.
 
 Scan/status/check/measure are read-only for source files. The scan loop writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded `.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`, one delimited guidance block in an existing agent file or new `AGENTS.md`, a managed `.opcore/` line in `.gitignore` for Git repos, and `.opcore/init-undo.json`. Undo recorded setup with `opcore init --undo`.
 
@@ -57,9 +62,15 @@ opcore try
 - `opcore measure` reads existing metric artifacts and reports named deltas, not a blended rating.
 - `opcore try` creates local sample repos and runs the demo loop without publishing anything.
 
-## Repeat Use
+## Package Publication
 
-Install globally when you expect to run Opcore repeatedly:
+After package publication, the one-command first-run path is:
+
+```bash
+npx @the-open-engine/opcore@0.1.0-alpha.0 init
+```
+
+After package publication, install globally when you expect to run Opcore repeatedly:
 
 ```bash
 npm install -g @the-open-engine/opcore@0.1.0-alpha.0
@@ -82,7 +93,12 @@ Alpha package artifacts target `darwin-arm64`, `darwin-x64`, and `linux-x64` wit
 
 ## Advanced ASP Provider Note
 
-**Providers assess; ASP hosts decide.** `opcore-asp-provider --stdio` can return Opcore validation assessments to an ASP host. Provider output is evidence for the host to evaluate, not authority to decide policy, enforce gates, or apply changes.
+**Providers assess; ASP hosts decide.** The aggregate `@the-open-engine/opcore`
+package exposes only the `opcore` bin. `opcore-asp-provider --stdio` is provided
+by the separate `@the-open-engine/opcore-asp-provider` package, or by
+`node packages/asp-provider/dist/index.js --stdio` from a built source checkout.
+Provider output is evidence for the host to evaluate, not authority to decide
+policy, enforce gates, or apply changes.
 
 ## Docs
 

--- a/scripts/check-release-hygiene.mjs
+++ b/scripts/check-release-hygiene.mjs
@@ -58,6 +58,9 @@ for (const token of ["npm\", [\"token\", \"list\", \"--json\"]", "bypass_2fa", "
 const readme = readFileSync("README.md", "utf8");
 for (const token of [
   "Local code scans, honest coverage, setup guidance, and changed-file validation for coding agents.",
+  "Package publication is maintainer-controlled during alpha staging",
+  "node packages/opcore/dist/index.js init --repo /path/to/repo",
+  "After package publication",
   "npm install -g @the-open-engine/opcore@0.1.0-alpha.0",
   "opcore try",
   "opcore --repo .",

--- a/scripts/check-workspace.mjs
+++ b/scripts/check-workspace.mjs
@@ -188,6 +188,8 @@ for (const [name, content] of [
 }
 for (const token of [
   "Opcore",
+  "Package publication is maintainer-controlled during alpha staging",
+  "node packages/opcore/dist/index.js init --repo /path/to/repo",
   "npm install -g @the-open-engine/opcore@0.1.0-alpha.0",
   "opcore try",
   "opcore --repo .",
@@ -203,6 +205,9 @@ for (const [name, content] of [
   ["packages/opcore/README.md", opcorePackageReadme]
 ]) {
   for (const token of [
+    "Package publication is maintainer-controlled during alpha staging",
+    "node packages/opcore/dist/index.js init --repo /path/to/repo",
+    "After package publication",
     "npx @the-open-engine/opcore@0.1.0-alpha.0 init",
     "npm install -g @the-open-engine/opcore@0.1.0-alpha.0",
     "npm prefix -g",
@@ -213,7 +218,9 @@ for (const [name, content] of [
     "Unsupported platforms return typed degraded status",
     "Windows is out of scope for `0.1.0-alpha.0`",
     "freshly `git init` repo with no commits",
-    "opcore check --changed --json"
+    "opcore check --changed --json",
+    "@the-open-engine/opcore",
+    "package exposes only"
   ]) {
     requireIncludes(name, content, token);
   }


### PR DESCRIPTION
Problem
The launch docs advertised npm/npx package-manager paths even though the alpha packages are maintainer-controlled and not published yet. That made first-run install instructions fail before users could evaluate Opcore.

Approach
Document the source-checkout command path as the current alpha path, move npm/npx commands under post-publication sections, and clarify that `opcore-asp-provider` comes from the separate provider package or source entrypoint rather than `@the-open-engine/opcore`.

Verification
- npm run ci
- node scripts/check-workspace.mjs
- node scripts/check-release-hygiene.mjs
- node --test tests/launch-claim-scrub.test.mjs
- node packages/opcore/dist/index.js check changed --base origin/main --json
- npm run current-tools:validate-changed
- npm run current-tools:validate-rust-graph