### PR TITLE
fix: make built opcore bin executable

### DIFF
--- a/scripts/write-cli-descriptor.mjs
+++ b/scripts/write-cli-descriptor.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { descriptorArtifactPath, opcoreManagedToolDescriptor } from "../packages/opcore/dist/advanced/descriptor.js";
@@ -29,3 +29,4 @@ for (const entry of readdirSync(outputDir, { withFileTypes: true })) {
 }
 rmSync(resolve(repoRoot, "packages", "opcore", "dist", "lattice"), { recursive: true, force: true });
 writeFileSync(outputPath, `${JSON.stringify(descriptor, null, 2)}\n`);
+chmodSync(resolve(repoRoot, "packages", "opcore", "dist", "index.js"), 0o755);

--- a/tests/package-identity.test.mjs
+++ b/tests/package-identity.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const expectedWorkspacePackages = new Map([
@@ -44,6 +44,16 @@ describe("Opcore public package identity", () => {
     );
     const oldCliPackage = ["packages", "cli"].join("/");
     assert.equal(existsSync(oldCliPackage), false, `${oldCliPackage} must not remain a package`);
+  });
+
+  it("marks packaged bin entrypoints executable after build", () => {
+    const binTargets = [
+      "packages/opcore/dist/index.js",
+      "packages/asp-provider/dist/index.js"
+    ];
+    for (const binTarget of binTargets) {
+      accessSync(binTarget, constants.X_OK);
+    }
   });
 
   it("keeps old public package identities out of release-facing package files", () => {


### PR DESCRIPTION
Problem
`packages/opcore/dist/index.js --help` failed with `permission denied` after a source build because TypeScript emitted the CLI entrypoint as a non-executable file. The ASP provider already chmods its generated bin, and current Rox/CRG/CIX wrappers are executable.

Approach
Apply the same executable-bit invariant when writing the Opcore CLI descriptor, and add package identity coverage that checks all packaged bin entrypoints are executable after build.

Verification
- packages/opcore/dist/index.js --help
- node --test tests/package-identity.test.mjs
- node scripts/check-workspace.mjs
- node packages/opcore/dist/index.js check changed --base origin/main --json
- npm run current-tools:validate-changed
- npm run current-tools:validate-rust-graph
- npm run ci