### PR TITLE
fix: label unsupported js module formats

### DIFF
--- a/packages/opcore/src/status.ts
+++ b/packages/opcore/src/status.ts
@@ -38,6 +38,7 @@ type SourcePolicyState = "supported" | "extraction_pending" | "retained" | "unsu
 
 interface SourcePolicy {
   language: string;
+  unsupportedStack?: string;
   graphSupported: boolean;
   validationSupported: boolean;
   retained: boolean;
@@ -56,8 +57,8 @@ function extractionPendingPolicy(language: string): SourcePolicy {
   return { language, graphSupported: false, validationSupported: false, retained: false, state: "extraction_pending" };
 }
 
-function unsupportedPolicy(language: string): SourcePolicy {
-  return { language, graphSupported: false, validationSupported: false, retained: false, state: "unsupported" };
+function unsupportedPolicy(language: string, unsupportedStack = language): SourcePolicy {
+  return { language, unsupportedStack, graphSupported: false, validationSupported: false, retained: false, state: "unsupported" };
 }
 
 // Keep this status policy in lockstep with crates/graph-core/src/extraction/language.rs.
@@ -74,8 +75,8 @@ const sourcePolicies = new Map<string, SourcePolicy>([
   ["Cargo.lock", retainedPolicy("Rust")],
   [".py", supportedPolicy("Python", true, true)],
   [".pyi", supportedPolicy("Python", true, true)],
-  [".mjs", unsupportedPolicy("JavaScript")],
-  [".cjs", unsupportedPolicy("JavaScript")],
+  [".mjs", unsupportedPolicy("JavaScript", "ESM JavaScript")],
+  [".cjs", unsupportedPolicy("JavaScript", "CommonJS JavaScript")],
   [".vue", unsupportedPolicy("Vue")],
   [".svelte", unsupportedPolicy("Svelte")],
   [".go", unsupportedPolicy("Go")],
@@ -468,7 +469,7 @@ function computeCoverage(files: readonly string[]): OpcoreRepoStatePayload["cove
     }
     if (retained) retainedFiles += 1;
     if (policy && !graphSupported && !validationSupported && !retained) {
-      const current = unsupportedCounts.get(kind) ?? { language: policy.language, count: 0, examples: [] };
+      const current = unsupportedCounts.get(kind) ?? { language: policy.unsupportedStack ?? policy.language, count: 0, examples: [] };
       current.count += 1;
       if (current.examples.length < 3) current.examples.push(file);
       unsupportedCounts.set(kind, current);

--- a/tests/opcore-facade.test.mjs
+++ b/tests/opcore-facade.test.mjs
@@ -114,6 +114,43 @@ describe("opcore public facade", () => {
     });
   });
 
+  it("labels unsupported JavaScript module formats distinctly from supported JavaScript", () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-js-module-status-"));
+    try {
+      writeFixtureFile(temp, "src/app.js", "export const value = 1;\n");
+      writeFixtureFile(temp, "scripts/bootstrap.cjs", "module.exports = { value: 1 };\n");
+      writeFixtureFile(temp, "scripts/config.mjs", "export const config = {};\n");
+
+      const result = parseJson(runOpcore(["status", "--repo", temp, "--json"], temp, 0).stdout);
+      const coverage = result.repoState.coverage;
+
+      assert.deepEqual(coverage.languages, [
+        { language: "JavaScript", files: 3, graphSupported: true, validationSupported: true }
+      ]);
+      assert.equal(coverage.graph.supportedFiles, 1);
+      assert.equal(coverage.validation.supportedFiles, 1);
+      assert.equal(coverage.unsupported.totalFiles, 2);
+      assert.deepEqual(
+        coverage.unsupported.stacks.map((stack) => ({
+          extension: stack.extension,
+          language: stack.language,
+          count: stack.count
+        })),
+        [
+          { extension: ".cjs", language: "CommonJS JavaScript", count: 1 },
+          { extension: ".mjs", language: "ESM JavaScript", count: 1 }
+        ]
+      );
+      assert.equal(coverage.unsupported.stacks.some((stack) => stack.language === "JavaScript"), false);
+
+      const human = runOpcore(["status", "--repo", temp], temp, 0);
+      assert.match(human.stdout, /unsupported=CommonJS JavaScript 1, ESM JavaScript 1/);
+      assert.doesNotMatch(human.stdout, /unsupported=JavaScript 1, JavaScript 1/);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   it("hides ASP state from non-enrolled human status", () => {
     const temp = mkdtempSync(join(tmpdir(), "opcore-status-no-asp-"));
     try {


### PR DESCRIPTION
Problem

Opcore status grouped unsupported .cjs and .mjs files under the same JavaScript language label while also reporting JavaScript as supported. On Covibes this made unsupported coverage read as duplicate JavaScript stacks instead of unsupported module formats.

Approach

Keep .cjs and .mjs unsupported, but give unsupported stack rows distinct display labels: CommonJS JavaScript and ESM JavaScript. The underlying language remains JavaScript for coverage aggregation.

Verification

- node --test tests/opcore-facade.test.mjs
- node packages/opcore/dist/index.js check changed --base origin/main --json
- npm run current-tools:validate-changed
- npm run current-tools:validate-rust-graph
- Compared Covibes status with current CRG: Opcore now reports .cjs as CommonJS JavaScript and .mjs as ESM JavaScript; CRG has no equivalent unsupported-stack coverage surface.