### PR TITLE
docs: clarify graph help and scan artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ npm run build
 node packages/opcore/dist/index.js init --repo /path/to/repo
 ```
 
-`opcore init` detects supported stacks, runs a read-only first scan, prints
-Coverage before Findings, reports concrete counts and locations, proposes repo
-setup, and asks before writing anything.
+`opcore init` detects supported stacks and runs a read-only first scan. When the
+scan completes, it prints Coverage before Findings, reports concrete counts and
+locations, proposes repo setup, and asks before writing anything.
 
-Scan/status/check/measure are read-only for source files. The scan loop writes
-only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded
+Scan/status/check/measure are read-only for source files. A successful scan loop
+writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded
 `.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`,
 one delimited guidance block in an existing agent file or new `AGENTS.md`, a
 managed `.opcore/` `.gitignore` line for Git repos, and
@@ -51,11 +51,11 @@ opcore init
 Run bare `opcore` after install for the read-only scan loop. A scoped scan is
 available as `opcore --repo .`.
 
-`opcore init` is scan-first and ask-before-write on a TTY: it prints coverage
-before findings, shows the additive setup plan, then writes only after an
-explicit yes. `opcore init --json` previews without writing; `opcore init
---approve --json` applies additive setup without prompting and returns scan,
-language settings, interaction, and timing fields.
+`opcore init` is scan-first and ask-before-write on a TTY: after the read-only
+scan completes, it prints coverage before findings, shows the additive setup
+plan, then writes only after an explicit yes. `opcore init --json` previews
+without writing; `opcore init --approve --json` applies additive setup without
+prompting and returns scan, language settings, interaction, and timing fields.
 
 If `opcore` is not found after a global install, check npm's global prefix and
 put its `bin` directory on `PATH`:
@@ -128,9 +128,9 @@ rating or claim every-project Python coverage.
 
 Opcore is a local CLI facade over scan, init, check, and measure flows. The
 accepted runtime model is hybrid: Rust graph core plus TypeScript contracts and
-CLI adapters. Scan/status/check/measure are read-only for source files. The scan
-loop writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded
-`.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`,
+CLI adapters. Scan/status/check/measure are read-only for source files. A
+successful scan loop writes only `.opcore/report.json`, `.opcore/history.jsonl`,
+and bounded `.opcore/telemetry.jsonl`. Approved init writes only additive `.opcore/config`,
 one delimited guidance block in an existing agent file or new `AGENTS.md`, a
 managed `.opcore/` `.gitignore` line for Git repos, and
 `.opcore/init-undo.json`.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -45,7 +45,8 @@ opcore --repo . --json
 opcore measure --repo . --json
 ```
 
-The scan writes metric artifacts. Measure reads those artifacts and returns named signal counts and deltas without re-running validation.
+A successful scan writes metric artifacts. Measure reads those artifacts and
+returns named signal counts and deltas without re-running validation.
 
 ## Private Provider Mode
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,7 +12,7 @@ Findings are named signals such as `typescript.type_errors`, `rust.source_hygien
 
 ## Artifacts
 
-Allowed scan artifacts:
+Successful scans may write only these artifacts:
 
 ```text
 .opcore/report.json
@@ -22,8 +22,9 @@ Allowed scan artifacts:
 
 Telemetry is bounded command latency evidence capped at 500 records or 1 MiB.
 Scan/status/check/measure are read-only for source files. `opcore measure`
-reads the report and history artifacts and reports baseline/previous deltas. It
-does not run checks, build graph data, install packages, or edit source.
+reads existing report and history artifacts and reports baseline/previous
+deltas. It does not run checks, build graph data, install packages, or edit
+source.
 
 ## Init
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,8 +49,9 @@ Restart the shell or add that export to the shell startup file used by the envir
 
 ## After Setup Reference
 
-Scan reads the repo and writes only `.opcore/report.json`,
-`.opcore/history.jsonl`, and bounded `.opcore/telemetry.jsonl`.
+Scan reads the repo. When it completes successfully, it writes only
+`.opcore/report.json`, `.opcore/history.jsonl`, and bounded
+`.opcore/telemetry.jsonl`.
 
 Run this inside the repository you want to inspect:
 
@@ -96,7 +97,13 @@ opcore init --approve
 opcore init --repo . --approve
 ```
 
-`opcore init` runs the read-only scan first, prints coverage before findings, shows the additive setup plan, and prompts on a TTY. `opcore init --json` previews without writing. Approved init writes only the approved setup artifacts listed above. Non-Git repos skip `.gitignore`; undo removes only the managed line. The `.opcore/` ignore covers `.opcore/telemetry.jsonl`. JSON output includes scan, language settings, interaction, and timing fields.
+`opcore init` runs the read-only scan first. When the scan completes, it prints
+coverage before findings, shows the additive setup plan, and prompts on a TTY.
+`opcore init --json` previews without writing. Approved init writes only the
+approved setup artifacts listed above. Non-Git repos skip `.gitignore`; undo
+removes only the managed line. The `.opcore/` ignore covers
+`.opcore/telemetry.jsonl`. JSON output includes scan, language settings,
+interaction, and timing fields.
 
 ## Coverage Honesty
 
@@ -118,7 +125,7 @@ Private ASP hosts may launch the provider process behind host-owned decisions an
 opcore-asp-provider --stdio
 ```
 
-The aggregate `@the-open-engine/opcore` package exposes only `opcore`;
+The aggregate `@the-open-engine/opcore` package exposes only the `opcore` bin;
 `opcore-asp-provider` comes from the separate
 `@the-open-engine/opcore-asp-provider` package. From a built source checkout,
 use `node packages/asp-provider/dist/index.js --stdio`.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3399,8 +3399,13 @@ function commandHelpMessage(groupName?: string): string {
   return [
     `${group.canonicalCommand.join(" ")} - ${group.summary}`,
     `Commands: ${group.commands.join(", ")}`,
+    ...(groupName === "graph" ? [`Syntax: ${contractHelpSyntax(group)}`] : []),
     `Example: ${contractHelpExample(groupName)}`
   ].join("\n");
+}
+
+function contractHelpSyntax(group: CommandGroupContract): string {
+  return `${group.canonicalCommand.join(" ")} <${group.commands.join("|")}> --repo . [--json]`;
 }
 
 function contractHelpExample(groupName: string): string {

--- a/packages/opcore/src/advanced/router.ts
+++ b/packages/opcore/src/advanced/router.ts
@@ -181,7 +181,7 @@ function helpMessage(groupName?: string): string {
       "  opcore <group> <command> [options]",
       "",
       "Groups:",
-      "  graph      build/search/query repository graph context",
+      "  graph      build, update, watch, query, search, and serve repository graph context",
       "  inspect    read symbols, definitions, references, signatures, implementations, and search results",
       "  edit       create and apply validation-gated edit plans",
       "  check      run syntax, type, graph-aware, and manifest checks",
@@ -234,7 +234,7 @@ function graphStatusAdvice(validationStatus: ValidationStatusPayload): string {
 }
 
 function groupSyntax(groupName: string): string {
-  if (groupName === "graph") return "opcore graph <build|status|search|impact|query> --repo . [--json]";
+  if (groupName === "graph") return commandGroupSyntax("graph");
   if (groupName === "inspect") return "opcore inspect <symbols|definition|references|signature|implementations|search> <target> --repo . [--json]";
   if (groupName === "edit") return "opcore edit <exact|patch|tree|rename|move|signature> --repo . [--json]";
   if (groupName === "check") return "opcore check <files|changed|staged|tree|all|manifest> --repo . [--json]";
@@ -242,6 +242,12 @@ function groupSyntax(groupName: string): string {
   if (groupName === "status") return "opcore status [--json]";
   if (groupName === "doctor") return "opcore doctor [--json]";
   return `opcore ${groupName} <command> [options]`;
+}
+
+function commandGroupSyntax(groupName: string): string {
+  const group = commandGroupByName(groupName);
+  if (!group) throw new Error(`Opcore ${groupName} command group is missing from command router manifest`);
+  return `${group.canonicalCommand.join(" ")} <${group.commands.join("|")}> --repo . [--json]`;
 }
 
 function groupExample(groupName: string): string {

--- a/packages/opcore/src/router.ts
+++ b/packages/opcore/src/router.ts
@@ -1,5 +1,5 @@
 import type { CommandRouterResult, ParsedCommandArgv } from "@the-open-engine/opcore-contracts";
-import { createCommandRouterResult, normalizeCommandBin, parseCommandArgv } from "@the-open-engine/opcore-contracts";
+import { commandGroupByName, createCommandRouterResult, normalizeCommandBin, parseCommandArgv } from "@the-open-engine/opcore-contracts";
 import { routeOpcoreCheck } from "./check.js";
 import {
   createOpcoreMeasureDelta,
@@ -218,7 +218,7 @@ function opcoreHelpMessage(): string {
     "  opcore init --undo --approve [--repo <path>] [--json]",
     "  opcore measure [--repo <path>] [--json]",
     "  opcore try [--json]",
-    "  opcore graph <build|status|search|impact|query> --repo . [--json]",
+    `  ${graphCommandSyntax()}`,
     "  opcore inspect <symbols|definition|references|signature|implementations|search> <target> --repo . [--json]",
     "  opcore edit <exact|patch|tree|rename|move|signature> --repo . [--json]",
     "  opcore validate <request|hypothetical|pre-write|manifest> --request-file <file> --json",
@@ -231,6 +231,12 @@ function opcoreHelpMessage(): string {
     "",
     "Exit codes: 0 passed, 1 findings or errors, 64 unsupported."
   ].join("\n");
+}
+
+function graphCommandSyntax(): string {
+  const graphGroup = commandGroupByName("graph");
+  if (!graphGroup) throw new Error("Opcore graph command group is missing from command router manifest");
+  return `${graphGroup.canonicalCommand.join(" ")} <${graphGroup.commands.join("|")}> --repo . [--json]`;
 }
 
 function shouldWriteLatencyTelemetry(result: CommandRouterResult): result is CommandRouterResult & { repoState: NonNullable<CommandRouterResult["repoState"]> } {

--- a/tests/command-router.test.mjs
+++ b/tests/command-router.test.mjs
@@ -6,6 +6,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } fro
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { routeOpcoreCommand } from "../packages/opcore/dist/index.js";
 import { commandRouterManifest, routeCommand, runCli } from "../packages/opcore/dist/advanced/index.js";
 
 const removedLegacyCommandField = `legacy${"Command"}`;
@@ -373,6 +374,11 @@ describe("Opcore command router", () => {
     assert.match(help, /Groups: graph, inspect, edit, check, validate, status, doctor/);
     assert.doesNotMatch(help, /\bstart\b/);
     assert.doesNotMatch(help, /\bstop\b/);
+    const publicHelp = (await routeOpcoreCommand(["--help"])).message;
+    assert.match(publicHelp, /opcore graph <build\|update\|watch\|status\|query\|serve\|impact\|review-context\|detect-changes\|search> --repo \. \[--json]/);
+    const graphHelp = (await routeCommand(["graph", "--help"], "opcore")).message;
+    assert.match(graphHelp, /Commands: build, update, watch, status, query, serve, impact, review-context, detect-changes, search/);
+    assert.match(graphHelp, /opcore graph <build\|update\|watch\|status\|query\|serve\|impact\|review-context\|detect-changes\|search> --repo \. \[--json]/);
     const status = await routeCommand(["status", "--json"], "opcore");
     assert.equal(status.validationStatus.adapterRegistry.checkIds.length, 22);
     assert.equal(status.validationStatus.adapterRegistry.checkIds.includes("rust.cargo-check"), true);

--- a/tests/package-identity.test.mjs
+++ b/tests/package-identity.test.mjs
@@ -56,6 +56,21 @@ describe("Opcore public package identity", () => {
     }
   });
 
+  it("documents the ASP provider as a separate package from the Opcore CLI", () => {
+    const opcoreManifest = readJson("packages/opcore/package.json");
+    const providerManifest = readJson("packages/asp-provider/package.json");
+    assert.deepEqual(opcoreManifest.bin, { opcore: "dist/index.js" });
+    assert.deepEqual(providerManifest.bin, { "opcore-asp-provider": "dist/index.js" });
+
+    for (const path of ["README.md", "docs/quickstart.md", "packages/opcore/README.md"]) {
+      const content = readFileSync(path, "utf8");
+      assert.match(content, /opcore-asp-provider --stdio/, path);
+      assert.match(content, /@the-open-engine\/opcore-asp-provider/, path);
+      assert.match(content, /@the-open-engine\/opcore/, path);
+      assert.match(content, /(?:provides|exposes) only (?:the )?`opcore` bin/, path);
+    }
+  });
+
   it("keeps old public package identities out of release-facing package files", () => {
     const checkedFiles = [
       "package.json",


### PR DESCRIPTION
## Summary
- Clarifies scan/init docs so artifact writes are described as successful-scan outputs, not unconditional behavior.
- Derives graph help syntax from the command manifest so top-level and graph help list the full graph command surface.
- Documents and tests that `opcore-asp-provider --stdio` comes from `@the-open-engine/opcore-asp-provider`, separate from the aggregate `opcore` bin.

## Verification
- `npm run build`
- `node --test tests/package-identity.test.mjs`
- `node --test tests/command-router.test.mjs`
- `node --test --test-name-pattern "rejects lifecycle commands and omits them from help" tests/cli-canonical-surface.test.mjs`
- `node scripts/check-workspace.mjs`
- `node scripts/check-release-hygiene.mjs`
- `node packages/opcore/dist/index.js check changed --base origin/main --json`
- `npm run current-tools:validate-changed`
- `npm run current-tools:validate-rust-graph`