### PR TITLE
fix: compact validation json output

### DIFF
--- a/packages/opcore/src/advanced/router.ts
+++ b/packages/opcore/src/advanced/router.ts
@@ -17,6 +17,7 @@ import {
   createDefaultValidationStatusPayload,
   validateCommandAdapter
 } from "./validation-composition.js";
+import { commandRouterResultForJsonOutput } from "../json-output.js";
 
 declare const process: {
   stdout: {
@@ -68,7 +69,7 @@ export async function runCli(options: RunCliOptions): Promise<number> {
   const stderr = options.stderr ?? ((text: string) => process.stderr.write(text));
   const routed = await routeCommand(options.argv, options.bin);
   if (routed.json) {
-    stdout(`${JSON.stringify(routed)}\n`);
+    stdout(`${JSON.stringify(commandRouterResultForJsonOutput(routed))}\n`);
   } else if (routed.status === "ok") {
     stdout(`${routed.message}\n`);
   } else {

--- a/packages/opcore/src/json-output.ts
+++ b/packages/opcore/src/json-output.ts
@@ -1,0 +1,36 @@
+import type {
+  CommandRouterResult,
+  ValidationResult,
+  ValidationResultManifest
+} from "@the-open-engine/opcore-contracts";
+
+export function commandRouterResultForJsonOutput(result: CommandRouterResult): CommandRouterResult {
+  if (!result.json || result.validationResult?.manifest === undefined) return result;
+  if (isValidationManifestCommand(result.canonicalCommand)) return result;
+  return {
+    ...result,
+    validationResult: compactValidationResult(result.validationResult)
+  };
+}
+
+function compactValidationResult(result: ValidationResult): ValidationResult {
+  if (result.manifest === undefined) return result;
+  return {
+    ...result,
+    manifest: compactValidationManifest(result.manifest)
+  };
+}
+
+function compactValidationManifest(manifest: ValidationResultManifest): ValidationResultManifest {
+  const compact: ValidationResultManifest = {
+    schemaVersion: manifest.schemaVersion,
+    checks: [...manifest.checks],
+    generatedAt: manifest.generatedAt
+  };
+  if (manifest.durationMs !== undefined) compact.durationMs = manifest.durationMs;
+  return compact;
+}
+
+function isValidationManifestCommand(canonicalCommand: readonly string[]): boolean {
+  return canonicalCommand[0] === "opcore" && (canonicalCommand[1] === "check" || canonicalCommand[1] === "validate") && canonicalCommand[2] === "manifest";
+}

--- a/packages/opcore/src/router.ts
+++ b/packages/opcore/src/router.ts
@@ -16,6 +16,7 @@ import { parseOpcoreRepoArgs, resolveRepo, routeOpcoreStatus } from "./status.js
 import { createCommandLatencyRecord, timeCommand } from "./timing.js";
 import { routeOpcoreTry } from "./try.js";
 import { routeCommand as routeAdvancedOpcoreCommand } from "./advanced/router.js";
+import { commandRouterResultForJsonOutput } from "./json-output.js";
 
 declare const process: {
   stdin: {
@@ -80,7 +81,7 @@ export async function runOpcoreCli(options: RunOpcoreCliOptions): Promise<number
     stdoutIsTTY: options.stdoutIsTTY ?? process.stdout.isTTY === true,
     readLine: options.readLine ?? createReadLine()
   });
-  const output = routed.json ? JSON.stringify(routed) : routed.message;
+  const output = routed.json ? JSON.stringify(commandRouterResultForJsonOutput(routed)) : routed.message;
   const write = routed.json || routed.status === "ok" ? stdout : stderr;
   write(`${output}\n`);
   return routed.exitCode;

--- a/tests/opcore-facade.test.mjs
+++ b/tests/opcore-facade.test.mjs
@@ -298,7 +298,11 @@ describe("opcore public facade", () => {
       assert.equal(result.owner, "validation");
       assert.equal(result.validationResult.ok, true);
       assert.equal(result.validationResult.status, "passed");
-      assert.equal(result.validationResult.manifest.runs[0].checkId, "typescript.syntax");
+      assert.deepEqual(result.validationResult.manifest.checks, ["typescript.syntax"]);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "entries"), false);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "runs"), false);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "skippedChecks"), false);
+      assert.equal(result.timing.phases.some((phase) => phase.phase === "validation_typescript_syntax"), true);
     });
   });
 
@@ -315,7 +319,11 @@ describe("opcore public facade", () => {
       assert.equal(result.owner, "validation");
       assert.equal(result.validationResult.ok, true);
       assert.equal(result.validationResult.status, "passed");
-      assert.equal(result.validationResult.manifest.runs[0].checkId, "typescript.syntax");
+      assert.deepEqual(result.validationResult.manifest.checks, ["typescript.syntax"]);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "entries"), false);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "runs"), false);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "skippedChecks"), false);
+      assert.equal(result.timing.phases.some((phase) => phase.phase === "validation_typescript_syntax"), true);
     });
   });
 

--- a/tests/validation-cli.test.mjs
+++ b/tests/validation-cli.test.mjs
@@ -74,7 +74,11 @@ describe("validation CLI", () => {
       const result = run(args, [0, 1]);
       assert.equal(result.owner, "validation");
       assert.equal(result.exitCode === 0 || result.exitCode === 1, true);
-      assert.equal(result.validationResult.manifest.entries.length, defaultCheckIds.length);
+      assert.equal(result.validationResult.manifest.checks.length, defaultCheckIds.length);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "entries"), false);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "runs"), false);
+      assert.equal(Object.hasOwn(result.validationResult.manifest, "skippedChecks"), false);
+      assert.equal(result.timing.phases.some((phase) => phase.phase === "validation_typescript_syntax"), true);
     }
   });
 


### PR DESCRIPTION
## Summary
- Compacts normal validation JSON output to keep `manifest` at `schemaVersion`, `checks`, `generatedAt`, and `durationMs`.
- Preserves full `check manifest --json` and `validate manifest --json` inventories.
- Applies compaction only at CLI JSON serialization so internal command results still retain run details for timing and telemetry.

## Canonical Comparison
- Covibes Rox probe: `rox check --files package.json --json --no-daemon` returned a concise top-level result array with no `manifest` or `validationResult` payload. CRG/CIX do not expose the equivalent validation-manifest JSON surface.

## Verification
- `npm run build`
- `node --test tests/validation-cli.test.mjs`
- `node --test tests/opcore-facade.test.mjs`
- `node --test tests/command-router.test.mjs`
- `node packages/opcore/dist/index.js check changed --base origin/main --json`
- `node scripts/check-workspace.mjs`
- `node scripts/check-release-hygiene.mjs`
- `npm run current-tools:validate-changed`
- `npm run current-tools:validate-rust-graph`