### PR TITLE
fix(graph): lock watch sessions before writing pid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +475,7 @@ name = "opcore-graph-core"
 version = "0.1.0-alpha.0"
 dependencies = [
  "ctrlc",
+ "fs2",
  "globset",
  "oxc_allocator",
  "oxc_ast",
@@ -1223,6 +1234,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1257,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/graph-core/Cargo.toml
+++ b/crates/graph-core/Cargo.toml
@@ -15,6 +15,7 @@ name = "opcore-graph-core"
 path = "src/main.rs"
 
 [dependencies]
+fs2 = "0.4.3"
 globset = "0.4.18"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"

--- a/crates/graph-core/src/daemon.rs
+++ b/crates/graph-core/src/daemon.rs
@@ -28,6 +28,8 @@ use validation::validate_request;
 
 const GRAPH_DAEMON_PROTOCOL: &str = "opcore.graph.daemon";
 
+pub(crate) use lifecycle::{process_is_alive, read_daemon_pid};
+
 #[derive(Debug, Clone)]
 struct ResponseParts {
     status: GraphProviderStatus,

--- a/crates/graph-core/src/daemon/lifecycle.rs
+++ b/crates/graph-core/src/daemon/lifecycle.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
 };
 use crate::{GRAPH_PROVIDER_NAME, GRAPH_SCHEMA_VERSION};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 pub(super) fn lifecycle_status(repo_root: &str) -> Option<GraphProviderStatus> {
     let daemon_dir = std::path::Path::new(repo_root)
@@ -138,7 +138,7 @@ fn stale_active_lifecycle_status(
     None
 }
 
-fn read_daemon_pid(pid_path: &Path) -> Result<u32, String> {
+pub(crate) fn read_daemon_pid(pid_path: &Path) -> Result<u32, String> {
     let content = std::fs::read_to_string(pid_path).map_err(|error| {
         format!(
             "graph watch daemon pid file {} is unreadable: {error}",
@@ -153,7 +153,7 @@ fn read_daemon_pid(pid_path: &Path) -> Result<u32, String> {
     })
 }
 
-fn process_is_alive(pid: u32) -> bool {
+pub(crate) fn process_is_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
@@ -165,6 +165,8 @@ fn process_is_alive_platform(pid: u32) -> bool {
     Command::new("kill")
         .arg("-0")
         .arg(pid.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()
         .map(|status| status.success())
         .unwrap_or(false)

--- a/crates/graph-core/src/watch.rs
+++ b/crates/graph-core/src/watch.rs
@@ -1,13 +1,12 @@
 use crate::extraction::normalize_watch_paths;
-use crate::pipeline::{display_path, now_rfc3339, update_snapshot, GraphPipelineOptions};
+use crate::pipeline::{display_path, update_snapshot, GraphPipelineOptions};
 use crate::protocol::{
     available_status_with_wal_checkpoint, query_failed_status, warming_status,
     AvailableStatusInput, GraphDaemonResponse, GraphFreshness, GraphPipelineResult,
     GraphProviderStatus, GraphWatchLifecycle, GraphWatchLifecycleState, RepoIdentity,
 };
 use crate::GRAPH_SCHEMA_VERSION;
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -15,11 +14,15 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 mod args;
+mod session;
 use args::parse_watch_args;
+use session::{write_lifecycle_state, WatchSession};
 
 const GRAPH_DAEMON_PROTOCOL: &str = "opcore.graph.daemon";
 pub const DEFAULT_WATCH_IDLE_TIMEOUT_MS: u64 = 1_800_000;
 pub const WATCH_IDLE_TIMEOUT_ENV: &str = "LATTICE_GRAPH_WATCH_IDLE_TIMEOUT_MS";
+
+type KindCounts = BTreeMap<String, u32>;
 
 #[derive(Debug, Clone)]
 pub struct WatchCliOptions {
@@ -126,21 +129,7 @@ fn watch_response_from_pipeline(
     mut pipeline: GraphPipelineResult,
 ) -> Result<GraphDaemonResponse, String> {
     if !watch_pipeline_available(&pipeline.status) {
-        let message = watch_pipeline_status_message(&pipeline.status);
-        let stale = matches!(pipeline.status, GraphProviderStatus::Stale { .. });
-        let state = if stale {
-            GraphWatchLifecycleState::Available
-        } else {
-            GraphWatchLifecycleState::Error
-        };
-        let lifecycle = write_lifecycle_state(session, state, Some(message.clone()))?;
-        if stale {
-            session.log(&format!("stale: {message}"))?;
-        } else {
-            session.log(&format!("unavailable: {message}"))?;
-        }
-        pipeline.lifecycle = Some(lifecycle.clone());
-        return Ok(watch_response_for_pipeline(pipeline, lifecycle));
+        return unavailable_watch_response_from_pipeline(session, pipeline);
     }
 
     let lifecycle = write_lifecycle_state(
@@ -149,14 +138,7 @@ fn watch_response_from_pipeline(
         Some("graph watch daemon available".to_string()),
     )?;
     session.log("available")?;
-    let (nodes_by_kind, edges_by_kind) = match &pipeline.status {
-        GraphProviderStatus::Available {
-            nodes_by_kind,
-            edges_by_kind,
-            ..
-        } => (Some(nodes_by_kind.clone()), Some(edges_by_kind.clone())),
-        _ => (None, None),
-    };
+    let (nodes_by_kind, edges_by_kind) = available_status_counts(&pipeline.status);
     pipeline.lifecycle = Some(lifecycle.clone());
     pipeline.status = available_status_with_wal_checkpoint(AvailableStatusInput {
         repo: session.repo.clone(),
@@ -170,6 +152,47 @@ fn watch_response_from_pipeline(
         wal_checkpoint: pipeline.summary.wal_checkpoint.clone(),
     });
     Ok(watch_response_for_pipeline(pipeline, lifecycle))
+}
+
+fn unavailable_watch_response_from_pipeline(
+    session: &WatchSession,
+    mut pipeline: GraphPipelineResult,
+) -> Result<GraphDaemonResponse, String> {
+    let message = watch_pipeline_status_message(&pipeline.status);
+    let stale = matches!(pipeline.status, GraphProviderStatus::Stale { .. });
+    let state = if stale {
+        GraphWatchLifecycleState::Available
+    } else {
+        GraphWatchLifecycleState::Error
+    };
+    let lifecycle = write_lifecycle_state(session, state, Some(message.clone()))?;
+    log_unavailable_watch_pipeline(session, stale, &message)?;
+    pipeline.lifecycle = Some(lifecycle.clone());
+    Ok(watch_response_for_pipeline(pipeline, lifecycle))
+}
+
+fn log_unavailable_watch_pipeline(
+    session: &WatchSession,
+    stale: bool,
+    message: &str,
+) -> Result<(), String> {
+    if stale {
+        return session.log(&format!("stale: {message}"));
+    }
+    session.log(&format!("unavailable: {message}"))
+}
+
+fn available_status_counts(
+    status: &GraphProviderStatus,
+) -> (Option<KindCounts>, Option<KindCounts>) {
+    match status {
+        GraphProviderStatus::Available {
+            nodes_by_kind,
+            edges_by_kind,
+            ..
+        } => (Some(nodes_by_kind.clone()), Some(edges_by_kind.clone())),
+        _ => (None, None),
+    }
 }
 
 fn watch_pipeline_available(status: &GraphProviderStatus) -> bool {
@@ -369,114 +392,6 @@ fn run_watch_update(
     pipeline_options.watch_paths = options.watch_paths.clone();
     pipeline_options.max_wal_bytes = options.max_wal_bytes;
     update_snapshot(pipeline_options).map_err(|error| error.to_string())
-}
-
-#[derive(Debug, Clone)]
-struct WatchPaths {
-    daemon_dir: PathBuf,
-    pid_path: PathBuf,
-    state_path: PathBuf,
-    log_path: PathBuf,
-}
-
-impl WatchPaths {
-    fn new(repo_root: &Path) -> Self {
-        let daemon_dir = repo_root.join(".lattice").join("graph").join("daemon");
-        Self {
-            pid_path: daemon_dir.join("pid"),
-            state_path: daemon_dir.join("state.json"),
-            log_path: daemon_dir.join("daemon.log"),
-            daemon_dir,
-        }
-    }
-}
-
-struct WatchSession {
-    paths: WatchPaths,
-    started_at: String,
-    repo: RepoIdentity,
-    poll_interval_ms: u64,
-    idle_timeout_ms: u64,
-    watch_paths: Vec<String>,
-}
-
-impl WatchSession {
-    fn start(repo_root: &Path, options: &WatchCliOptions) -> Result<Self, String> {
-        let paths = WatchPaths::new(repo_root);
-        fs::create_dir_all(&paths.daemon_dir)
-            .map_err(|error| format!("failed to create daemon dir: {error}"))?;
-        fs::write(&paths.pid_path, std::process::id().to_string())
-            .map_err(|error| format!("failed to write pid file: {error}"))?;
-        Ok(Self {
-            paths,
-            started_at: now_rfc3339(),
-            repo: repo_identity(repo_root),
-            poll_interval_ms: options.poll_interval_ms,
-            idle_timeout_ms: options.idle_timeout_ms,
-            watch_paths: options.watch_paths.clone(),
-        })
-    }
-
-    fn lifecycle(
-        &self,
-        state: GraphWatchLifecycleState,
-        message: Option<String>,
-    ) -> GraphWatchLifecycle {
-        GraphWatchLifecycle {
-            state,
-            pid: Some(std::process::id()),
-            started_at: self.started_at.clone(),
-            updated_at: now_rfc3339(),
-            pid_path: display_path(&self.paths.pid_path),
-            state_path: display_path(&self.paths.state_path),
-            log_path: display_path(&self.paths.log_path),
-            poll_interval_ms: self.poll_interval_ms,
-            idle_timeout_ms: self.idle_timeout_ms,
-            watch_paths: self.watch_paths.clone(),
-            message,
-        }
-    }
-
-    fn write_lifecycle(&self, lifecycle: &GraphWatchLifecycle) -> Result<(), String> {
-        fs::write(
-            &self.paths.state_path,
-            format!(
-                "{}\n",
-                serde_json::to_string_pretty(lifecycle)
-                    .map_err(|error| format!("failed to encode lifecycle: {error}"))?
-            ),
-        )
-        .map_err(|error| format!("failed to write lifecycle: {error}"))
-    }
-
-    fn log(&self, message: &str) -> Result<(), String> {
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.paths.log_path)
-            .map_err(|error| format!("failed to open daemon log: {error}"))?;
-        writeln!(file, "{} {message}", now_rfc3339())
-            .map_err(|error| format!("failed to write daemon log: {error}"))
-    }
-}
-
-fn write_lifecycle_state(
-    session: &WatchSession,
-    state: GraphWatchLifecycleState,
-    message: Option<String>,
-) -> Result<GraphWatchLifecycle, String> {
-    let lifecycle = session.lifecycle(state, message);
-    session.write_lifecycle(&lifecycle)?;
-    Ok(lifecycle)
-}
-
-fn repo_identity(repo_root: &Path) -> RepoIdentity {
-    RepoIdentity {
-        repo_id: None,
-        repo_root: Some(display_path(repo_root)),
-        remote_url: None,
-        commit_sha: None,
-    }
 }
 
 pub fn boundary_name() -> &'static str {

--- a/crates/graph-core/src/watch/session.rs
+++ b/crates/graph-core/src/watch/session.rs
@@ -1,0 +1,368 @@
+use super::WatchCliOptions;
+use crate::pipeline::{display_path, now_rfc3339};
+use crate::protocol::{GraphWatchLifecycle, GraphWatchLifecycleState, RepoIdentity};
+use fs2::FileExt;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+struct WatchPaths {
+    daemon_dir: PathBuf,
+    lock_path: PathBuf,
+    pid_path: PathBuf,
+    state_path: PathBuf,
+    log_path: PathBuf,
+}
+
+impl WatchPaths {
+    fn new(repo_root: &Path) -> Self {
+        let daemon_dir = repo_root.join(".lattice").join("graph").join("daemon");
+        Self {
+            lock_path: daemon_dir.join("watch.lock"),
+            pid_path: daemon_dir.join("pid"),
+            state_path: daemon_dir.join("state.json"),
+            log_path: daemon_dir.join("daemon.log"),
+            daemon_dir,
+        }
+    }
+}
+
+struct WatchLock {
+    file: fs::File,
+}
+
+impl WatchLock {
+    fn acquire(paths: &WatchPaths) -> Result<Self, String> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&paths.lock_path)
+            .map_err(|error| {
+                format!(
+                    "failed to open daemon lock {}: {error}",
+                    display_path(&paths.lock_path)
+                )
+            })?;
+        match file.try_lock_exclusive() {
+            Ok(()) => {
+                refuse_existing_live_watch(paths)?;
+                Ok(Self { file })
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                Err(daemon_lock_held_message(paths))
+            }
+            Err(error) => Err(format!(
+                "failed to acquire daemon lock {}: {error}",
+                display_path(&paths.lock_path)
+            )),
+        }
+    }
+}
+
+impl Drop for WatchLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+fn daemon_lock_held_message(paths: &WatchPaths) -> String {
+    if let Some(pid) = existing_live_watch_pid(paths) {
+        return format!(
+            "graph watch daemon already running with pid {pid}; pid file {} was not replaced",
+            display_path(&paths.pid_path)
+        );
+    }
+    format!(
+        "graph watch daemon lock {} is already held; pid file {} was not replaced",
+        display_path(&paths.lock_path),
+        display_path(&paths.pid_path)
+    )
+}
+
+fn refuse_existing_live_watch(paths: &WatchPaths) -> Result<(), String> {
+    if let Some(pid) = existing_live_watch_pid(paths) {
+        return Err(format!(
+            "graph watch daemon already running with pid {pid}; pid file {} was not replaced",
+            display_path(&paths.pid_path)
+        ));
+    }
+    Ok(())
+}
+
+fn existing_live_watch_pid(paths: &WatchPaths) -> Option<u32> {
+    let pid = crate::daemon::read_daemon_pid(&paths.pid_path).ok()?;
+    if !crate::daemon::process_is_alive(pid) {
+        return None;
+    }
+    if lifecycle_state_is_stopped(&paths.state_path) {
+        return None;
+    }
+    Some(pid)
+}
+
+fn lifecycle_state_is_stopped(state_path: &Path) -> bool {
+    fs::read_to_string(state_path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<GraphWatchLifecycle>(&content).ok())
+        .is_some_and(|lifecycle| lifecycle.state == GraphWatchLifecycleState::Stopped)
+}
+
+pub(super) struct WatchSession {
+    paths: WatchPaths,
+    _lock: Option<WatchLock>,
+    started_at: String,
+    pub(super) repo: RepoIdentity,
+    poll_interval_ms: u64,
+    idle_timeout_ms: u64,
+    watch_paths: Vec<String>,
+}
+
+impl WatchSession {
+    pub(super) fn start(repo_root: &Path, options: &WatchCliOptions) -> Result<Self, String> {
+        let paths = WatchPaths::new(repo_root);
+        fs::create_dir_all(&paths.daemon_dir)
+            .map_err(|error| format!("failed to create daemon dir: {error}"))?;
+        let lock = if options.once {
+            None
+        } else {
+            Some(WatchLock::acquire(&paths)?)
+        };
+        fs::write(&paths.pid_path, std::process::id().to_string())
+            .map_err(|error| format!("failed to write pid file: {error}"))?;
+        Ok(Self {
+            paths,
+            _lock: lock,
+            started_at: now_rfc3339(),
+            repo: repo_identity(repo_root),
+            poll_interval_ms: options.poll_interval_ms,
+            idle_timeout_ms: options.idle_timeout_ms,
+            watch_paths: options.watch_paths.clone(),
+        })
+    }
+
+    fn lifecycle(
+        &self,
+        state: GraphWatchLifecycleState,
+        message: Option<String>,
+    ) -> GraphWatchLifecycle {
+        GraphWatchLifecycle {
+            state,
+            pid: Some(std::process::id()),
+            started_at: self.started_at.clone(),
+            updated_at: now_rfc3339(),
+            pid_path: display_path(&self.paths.pid_path),
+            state_path: display_path(&self.paths.state_path),
+            log_path: display_path(&self.paths.log_path),
+            poll_interval_ms: self.poll_interval_ms,
+            idle_timeout_ms: self.idle_timeout_ms,
+            watch_paths: self.watch_paths.clone(),
+            message,
+        }
+    }
+
+    fn write_lifecycle(&self, lifecycle: &GraphWatchLifecycle) -> Result<(), String> {
+        fs::write(
+            &self.paths.state_path,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(lifecycle)
+                    .map_err(|error| format!("failed to encode lifecycle: {error}"))?
+            ),
+        )
+        .map_err(|error| format!("failed to write lifecycle: {error}"))
+    }
+
+    pub(super) fn log(&self, message: &str) -> Result<(), String> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.paths.log_path)
+            .map_err(|error| format!("failed to open daemon log: {error}"))?;
+        writeln!(file, "{} {message}", now_rfc3339())
+            .map_err(|error| format!("failed to write daemon log: {error}"))
+    }
+}
+
+pub(super) fn write_lifecycle_state(
+    session: &WatchSession,
+    state: GraphWatchLifecycleState,
+    message: Option<String>,
+) -> Result<GraphWatchLifecycle, String> {
+    let lifecycle = session.lifecycle(state, message);
+    session.write_lifecycle(&lifecycle)?;
+    Ok(lifecycle)
+}
+
+fn repo_identity(repo_root: &Path) -> RepoIdentity {
+    RepoIdentity {
+        repo_id: None,
+        repo_root: Some(display_path(repo_root)),
+        remote_url: None,
+        commit_sha: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::watch::{WatchCliOptions, DEFAULT_WATCH_IDLE_TIMEOUT_MS};
+    use fs2::FileExt;
+    use std::io;
+    use std::process::{Child, Command, Stdio};
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn start_refuses_live_active_watch_without_replacing_pid_file() -> TestResult {
+        let repo = tempfile::tempdir()?;
+        let paths = WatchPaths::new(repo.path());
+        fs::create_dir_all(&paths.daemon_dir)?;
+        let child = LiveChild::spawn()?;
+        let child_pid = child.id();
+        fs::write(&paths.pid_path, child_pid.to_string())?;
+        write_test_lifecycle(&paths, GraphWatchLifecycleState::Available, child_pid)?;
+
+        let result = WatchSession::start(repo.path(), &watch_options(repo.path(), false));
+
+        let message = result
+            .err()
+            .ok_or_else(|| io::Error::other("watch session unexpectedly started"))?;
+        assert!(message.contains(&format!("pid {child_pid}")), "{message}");
+        assert_eq!(
+            fs::read_to_string(&paths.pid_path)?.trim(),
+            child_pid.to_string()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn start_reclaims_dead_active_pid_for_new_session() -> TestResult {
+        let repo = tempfile::tempdir()?;
+        let paths = WatchPaths::new(repo.path());
+        fs::create_dir_all(&paths.daemon_dir)?;
+        let stale_pid = inactive_pid_candidate()?;
+        fs::write(&paths.pid_path, stale_pid.to_string())?;
+        write_test_lifecycle(&paths, GraphWatchLifecycleState::Available, stale_pid)?;
+
+        let session = WatchSession::start(repo.path(), &watch_options(repo.path(), false))
+            .map_err(io::Error::other)?;
+
+        assert_eq!(
+            fs::read_to_string(&paths.pid_path)?.trim(),
+            std::process::id().to_string()
+        );
+        drop(session);
+        Ok(())
+    }
+
+    #[test]
+    fn start_holds_lock_until_session_drops() -> TestResult {
+        let repo = tempfile::tempdir()?;
+        let paths = WatchPaths::new(repo.path());
+        let session = WatchSession::start(repo.path(), &watch_options(repo.path(), false))
+            .map_err(io::Error::other)?;
+        let competing_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&paths.lock_path)?;
+
+        assert!(competing_lock.try_lock_exclusive().is_err());
+        drop(session);
+        competing_lock.try_lock_exclusive()?;
+        competing_lock.unlock()?;
+        Ok(())
+    }
+
+    fn watch_options(repo_root: &Path, once: bool) -> WatchCliOptions {
+        WatchCliOptions {
+            repo_root: repo_root.to_path_buf(),
+            base_ref: None,
+            watch_paths: Vec::new(),
+            poll_interval_ms: 1000,
+            idle_timeout_ms: DEFAULT_WATCH_IDLE_TIMEOUT_MS,
+            once,
+            max_wal_bytes: crate::store::DEFAULT_WAL_BUDGET_BYTES,
+        }
+    }
+
+    fn write_test_lifecycle(
+        paths: &WatchPaths,
+        state: GraphWatchLifecycleState,
+        pid: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let lifecycle = GraphWatchLifecycle {
+            state,
+            pid: Some(pid),
+            started_at: "2026-06-28T00:00:00.000Z".to_string(),
+            updated_at: "2026-06-28T00:00:00.000Z".to_string(),
+            pid_path: display_path(&paths.pid_path),
+            state_path: display_path(&paths.state_path),
+            log_path: display_path(&paths.log_path),
+            poll_interval_ms: 1000,
+            idle_timeout_ms: DEFAULT_WATCH_IDLE_TIMEOUT_MS,
+            watch_paths: Vec::new(),
+            message: Some("graph watch daemon available".to_string()),
+        };
+        fs::write(&paths.state_path, serde_json::to_string_pretty(&lifecycle)?)?;
+        Ok(())
+    }
+
+    fn inactive_pid_candidate() -> Result<u32, io::Error> {
+        let start = std::process::id().saturating_add(1);
+        for candidate in start..u32::MAX {
+            if !crate::daemon::process_is_alive(candidate) {
+                return Ok(candidate);
+            }
+        }
+        Err(io::Error::other("could not find an inactive pid candidate"))
+    }
+
+    struct LiveChild {
+        child: Child,
+    }
+
+    impl LiveChild {
+        fn spawn() -> Result<Self, io::Error> {
+            Ok(Self {
+                child: sleep_command().spawn()?,
+            })
+        }
+
+        fn id(&self) -> u32 {
+            self.child.id()
+        }
+    }
+
+    impl Drop for LiveChild {
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+
+    #[cfg(unix)]
+    fn sleep_command() -> Command {
+        let mut command = Command::new("sleep");
+        command
+            .arg("60")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        command
+    }
+
+    #[cfg(windows)]
+    fn sleep_command() -> Command {
+        let mut command = Command::new("cmd");
+        command
+            .arg("/C")
+            .arg("ping -n 60 127.0.0.1 >NUL")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        command
+    }
+}


### PR DESCRIPTION
## Summary
- acquire a repo-local advisory watch lock before non-once graph watch writes daemon pid/state files
- refuse a second live watcher without replacing the existing pidfile
- preserve stale/dead pid reclaim and keep --once exempt per issue #140

## Genericity and parity
- paths derive from the supplied repo root and the existing .lattice/graph/daemon contract; no fixture repo assumptions
- this is Opcore graph-core lifecycle behavior; rox/cix daemon surfaces and crg watch help do not expose directly comparable pidfile-lock semantics

## Verification
- cargo fmt --check
- cargo clippy -p opcore-graph-core --all-targets --all-features --locked -- -D warnings
- cargo test -p opcore-graph-core
- node packages/opcore/dist/index.js check changed --base origin/main --json
- npm run current-tools:validate-changed
- git diff --check

Closes #140