### PR TITLE
perf(validation-typescript): share overlay programs

### DIFF
--- a/packages/opcore/src/scan.ts
+++ b/packages/opcore/src/scan.ts
@@ -12,7 +12,11 @@ import { readdir, readFile } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import { createOpcoreMetricReport, writeOpcoreMetricArtifacts } from "./reporting.js";
 import { commonSkippedPathSegments, createRepoState, parseOpcoreRepoArgs, type RepoResolution, resolveRepo } from "./status.js";
-import { createOpcoreValidationGraphProviderClient, defaultValidationChecks } from "./validation-composition.js";
+import {
+  createOpcoreValidationGraphProviderClient,
+  defaultValidationChecks,
+  opcorePublicValidationRuntimePolicy
+} from "./validation-composition.js";
 
 const skippedPathSegments = new Set<string>(commonSkippedPathSegments);
 
@@ -82,7 +86,8 @@ export async function createOpcoreScanAnalysis(resolution: RepoResolution): Prom
   const validationResult = await createValidationRunner({
     workspace: createScanWorkspace(resolution),
     checks: defaultValidationChecks,
-    graphProviderClient: createOpcoreValidationGraphProviderClient()
+    graphProviderClient: createOpcoreValidationGraphProviderClient(),
+    runtime: opcorePublicValidationRuntimePolicy
   }).runValidation(validationRequest);
   const metricReport = createOpcoreMetricReport({
     repoState,

--- a/packages/opcore/src/validation-composition.ts
+++ b/packages/opcore/src/validation-composition.ts
@@ -10,7 +10,8 @@ import {
   createValidationRunner,
   createValidationStatusPayload,
   type ValidationCommandAdapterOptions,
-  type ValidationGraphProviderClient
+  type ValidationGraphProviderClient,
+  type ValidationRuntimePolicy
 } from "@the-open-engine/opcore-validation";
 import { createPythonValidationAdapterStatus, createPythonValidationChecks } from "@the-open-engine/opcore-validation-python";
 import { createRustValidationAdapterStatus, createRustValidationChecks } from "@the-open-engine/opcore-validation-rust";
@@ -35,6 +36,10 @@ export const defaultValidationChecks = [
   ...createPythonValidationChecks()
 ];
 
+export const opcorePublicValidationRuntimePolicy: ValidationRuntimePolicy = {
+  persistentCaches: "disabled"
+};
+
 export const checkCommandAdapter = createCheckCommandAdapter(defaultValidationAdapterOptions());
 
 export const opcoreValidationRunner = {
@@ -45,7 +50,8 @@ export const opcoreValidationRunner = {
         skippedPathSegments: commonSkippedPathSegments
       }),
       checks: defaultValidationChecks,
-      graphProviderClient: createOpcoreValidationGraphProviderClient()
+      graphProviderClient: createOpcoreValidationGraphProviderClient(),
+      runtime: opcorePublicValidationRuntimePolicy
     }).runValidation(request);
   }
 };
@@ -67,6 +73,7 @@ function defaultValidationAdapterOptions(): ValidationCommandAdapterOptions {
   return {
     checks: defaultValidationChecks,
     graphProviderClient: createOpcoreValidationGraphProviderClient(),
+    runtime: opcorePublicValidationRuntimePolicy,
     workspaceFactory: (repoRoot) =>
       createNodeValidationWorkspace({
         repoRoot,

--- a/packages/validation-typescript/src/compiler-host.ts
+++ b/packages/validation-typescript/src/compiler-host.ts
@@ -1,70 +1,182 @@
-import type { ValidationCheckContext } from "@the-open-engine/opcore-validation";
+import type { ValidationCheckContext, ValidationFileView } from "@the-open-engine/opcore-validation";
 import ts from "typescript";
-import { resolveTypeScriptCompilerProjects } from "./compiler-options.js";
+import { resolveTypeScriptCompilerProjects, type ResolvedTypeScriptCompilerProject } from "./compiler-options.js";
 import { materializeTypeScriptSources, type TypeScriptMaterializedSourceSet } from "./source-files.js";
 
 export interface OverlayAwareTypeScriptProgram {
   program: ts.Program;
+  builderProgram?: ts.BuilderProgram;
   repoRoot: string;
   sourceSet: TypeScriptMaterializedSourceSet;
   configDiagnostics: readonly ts.Diagnostic[];
+  buildInfoPath?: string;
 }
 
 interface CreateOverlayAwareCompilerHostArgs {
   options: ts.CompilerOptions;
   repoRoot: string;
   sourceSet: TypeScriptMaterializedSourceSet;
+  incrementalBuildInfoPath?: string;
+}
+
+interface OverlayAwareCompilerHostState {
+  repoRoot: string;
+  sourceByPath: ReadonlyMap<string, string>;
+  sourcePaths: readonly string[];
+  normalizedBuildInfoPath?: string;
+}
+
+interface WriteIncrementalBuildInfoArgs {
+  fileName: string;
+  data: string;
+  writeByteOrderMark?: boolean;
+  onError?: (message: string) => void;
+  state: OverlayAwareCompilerHostState;
 }
 
 const virtualRepoRoot = "/__lattice_repo__";
+const typeScriptBuildInfoDirectory = ".opcore/typescript-build-info";
+const programCache = new WeakMap<ValidationFileView, Promise<readonly OverlayAwareTypeScriptProgram[]>>();
+
+interface BuildInfoEmitter {
+  emitBuildInfo: () => void;
+}
 
 export async function createOverlayAwareTypeScriptProgram(
   context: ValidationCheckContext
 ): Promise<OverlayAwareTypeScriptProgram> {
-  for await (const program of createOverlayAwareTypeScriptProgramIterator(context)) {
-    return program;
-  }
-  return emptyOverlayAwareTypeScriptProgram(context);
+  const programs = await createOverlayAwareTypeScriptPrograms(context);
+  return programs[0] ?? emptyOverlayAwareTypeScriptProgram(context);
 }
 
 export async function createOverlayAwareTypeScriptPrograms(
   context: ValidationCheckContext
 ): Promise<readonly OverlayAwareTypeScriptProgram[]> {
-  const programs: OverlayAwareTypeScriptProgram[] = [];
-  for await (const program of createOverlayAwareTypeScriptProgramIterator(context)) {
-    programs.push(program);
-  }
-  return programs;
+  const cached = programCache.get(context.fileView);
+  if (cached !== undefined) return cached;
+  const promise = createOverlayAwareTypeScriptProgramsUncached(context);
+  programCache.set(context.fileView, promise);
+  return promise;
 }
 
 export async function* createOverlayAwareTypeScriptProgramIterator(
   context: ValidationCheckContext
 ): AsyncGenerator<OverlayAwareTypeScriptProgram> {
+  for (const program of await createOverlayAwareTypeScriptPrograms(context)) {
+    yield program;
+  }
+}
+
+export function emitTypeScriptProgramBuildInfo(bundle: OverlayAwareTypeScriptProgram): void {
+  if (bundle.builderProgram === undefined || bundle.buildInfoPath === undefined) return;
+  if (!hasBuildInfoEmitter(bundle.builderProgram)) return;
+  try {
+    bundle.builderProgram.emitBuildInfo();
+  } catch {
+    // Build-info persistence is an optimization; diagnostics must not depend on cache writability.
+  }
+}
+
+async function createOverlayAwareTypeScriptProgramsUncached(
+  context: ValidationCheckContext
+): Promise<readonly OverlayAwareTypeScriptProgram[]> {
   const compilerProjects = await resolveTypeScriptCompilerProjects(context);
   const repoRoot = compilerRepoRoot(context);
+  const programs: OverlayAwareTypeScriptProgram[] = [];
   for (const compilerOptions of compilerProjects) {
     const sourceSet = await materializeTypeScriptSources(context, {
       compilerOptions: compilerOptions.options,
       rootPaths: compilerOptions.rootPaths,
       supportPaths: compilerOptions.supportPaths
     });
+    const buildInfoPath = typeScriptBuildInfoPath(context, repoRoot, compilerOptions, sourceSet);
+    const programOptions =
+      buildInfoPath === undefined
+        ? compilerOptions.options
+        : {
+            ...compilerOptions.options,
+            incremental: true,
+            tsBuildInfoFile: buildInfoPath
+          };
     const host = createOverlayAwareCompilerHost({
-      options: compilerOptions.options,
-      repoRoot,
-      sourceSet
-    });
-    const rootNames = sourceSet.files.map((file) => toCompilerFileName(file.path, repoRoot));
-    yield {
-      program: ts.createProgram({
-        rootNames,
-        options: compilerOptions.options,
-        host
-      }),
+      options: programOptions,
       repoRoot,
       sourceSet,
-      configDiagnostics: compilerOptions.diagnostics
-    };
+      ...(buildInfoPath === undefined ? {} : { incrementalBuildInfoPath: buildInfoPath })
+    });
+    const rootNames = sourceSet.files.map((file) => toCompilerFileName(file.path, repoRoot));
+    programs.push(
+      createProgramBundle({
+        rootNames,
+        options: programOptions,
+        fallbackOptions: compilerOptions.options,
+        repoRoot,
+        sourceSet,
+        configDiagnostics: compilerOptions.diagnostics,
+        buildInfoPath,
+        host
+      })
+    );
   }
+  return programs;
+}
+
+interface CreateProgramBundleArgs {
+  rootNames: readonly string[];
+  options: ts.CompilerOptions;
+  fallbackOptions: ts.CompilerOptions;
+  repoRoot: string;
+  sourceSet: TypeScriptMaterializedSourceSet;
+  configDiagnostics: readonly ts.Diagnostic[];
+  buildInfoPath?: string;
+  host: ts.CompilerHost;
+}
+
+function createProgramBundle(args: CreateProgramBundleArgs): OverlayAwareTypeScriptProgram {
+  if (args.buildInfoPath !== undefined) {
+    try {
+      const builderProgram = ts.createIncrementalProgram({
+        rootNames: args.rootNames,
+        options: args.options,
+        host: args.host
+      });
+      return {
+        program: builderProgram.getProgram(),
+        builderProgram,
+        repoRoot: args.repoRoot,
+        sourceSet: args.sourceSet,
+        configDiagnostics: args.configDiagnostics,
+        buildInfoPath: args.buildInfoPath
+      };
+    } catch {
+      const fallbackHost = createOverlayAwareCompilerHost({
+        options: args.fallbackOptions,
+        repoRoot: args.repoRoot,
+        sourceSet: args.sourceSet
+      });
+      return {
+        program: ts.createProgram({
+          rootNames: args.rootNames,
+          options: args.fallbackOptions,
+          host: fallbackHost
+        }),
+        repoRoot: args.repoRoot,
+        sourceSet: args.sourceSet,
+        configDiagnostics: args.configDiagnostics
+      };
+    }
+  }
+
+  return {
+    program: ts.createProgram({
+      rootNames: args.rootNames,
+      options: args.options,
+      host: args.host
+    }),
+    repoRoot: args.repoRoot,
+    sourceSet: args.sourceSet,
+    configDiagnostics: args.configDiagnostics
+  };
 }
 
 export function repoSourceFiles(bundle: OverlayAwareTypeScriptProgram): readonly ts.SourceFile[] {
@@ -95,78 +207,195 @@ export function toRepoRelativeCompilerPath(fileName: string, repoRoot: string): 
 }
 
 function createOverlayAwareCompilerHost(args: CreateOverlayAwareCompilerHostArgs): ts.CompilerHost {
-  const repoRoot = stripTrailingSlash(args.repoRoot);
-  const sourceByPath = new Map(args.sourceSet.files.map((file) => [file.path, file.content]));
-  const sourcePaths = [...sourceByPath.keys()];
-  const defaultHost = ts.createCompilerHost(args.options, true);
+  const state: OverlayAwareCompilerHostState = {
+    repoRoot: stripTrailingSlash(args.repoRoot),
+    sourceByPath: new Map(args.sourceSet.files.map((file) => [file.path, file.content])),
+    sourcePaths: args.sourceSet.files.map((file) => file.path),
+    ...(args.incrementalBuildInfoPath === undefined
+      ? {}
+      : { normalizedBuildInfoPath: normalizePath(args.incrementalBuildInfoPath) })
+  };
+  const defaultHost =
+    args.incrementalBuildInfoPath === undefined
+      ? ts.createCompilerHost(args.options, true)
+      : ts.createIncrementalCompilerHost(args.options, ts.sys);
   const host: ts.CompilerHost = {
     ...defaultHost,
-    getCurrentDirectory: () => repoRoot,
+    getCurrentDirectory: () => state.repoRoot,
     getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
     getCanonicalFileName: (fileName) => normalizePath(fileName),
     useCaseSensitiveFileNames: () => true,
-    fileExists: (fileName) => {
-      if (isTypeScriptLibraryFile(fileName)) return ts.sys.fileExists(fileName);
-      const repoPath = toRepoRelativeCompilerPath(fileName, repoRoot);
-      if (repoPath !== undefined) {
-        if (sourceByPath.has(repoPath)) return true;
-        return isDeterministicExternalRepoFile(repoPath) && ts.sys.fileExists(fileName);
-      }
-      return ts.sys.fileExists(fileName);
-    },
-    readFile: (fileName) => {
-      if (isTypeScriptLibraryFile(fileName)) return ts.sys.readFile(fileName);
-      const repoPath = toRepoRelativeCompilerPath(fileName, repoRoot);
-      if (repoPath !== undefined) {
-        const sourceContent = sourceByPath.get(repoPath);
-        if (sourceContent !== undefined) return sourceContent;
-        return isDeterministicExternalRepoFile(repoPath) ? ts.sys.readFile(fileName) : undefined;
-      }
-      return ts.sys.readFile(fileName);
-    },
-    directoryExists: (directoryName) => {
-      const repoPath = toRepoRelativeCompilerPath(directoryName, repoRoot);
-      if (repoPath !== undefined) {
-        if (repoPath.length === 0 || sourcePaths.some((path) => path.startsWith(`${repoPath}/`))) return true;
-        return isDeterministicExternalRepoDirectory(repoPath) && (ts.sys.directoryExists?.(directoryName) ?? false);
-      }
-      return ts.sys.directoryExists?.(directoryName) ?? false;
-    },
-    getDirectories: (directoryName) => {
-      const repoPath = toRepoRelativeCompilerPath(directoryName, repoRoot);
-      if (repoPath === undefined) return ts.sys.getDirectories?.(directoryName) ?? [];
-      if (isDeterministicExternalRepoDirectory(repoPath)) return ts.sys.getDirectories?.(directoryName) ?? [];
-      const prefix = repoPath.length === 0 ? "" : `${repoPath}/`;
-      const children = new Set<string>();
-      for (const path of sourcePaths) {
-        if (!path.startsWith(prefix)) continue;
-        const rest = path.slice(prefix.length);
-        const child = rest.split("/", 1)[0];
-        if (child !== undefined && rest.includes("/")) children.add(child);
-      }
-      return [...children].sort();
-    },
-    readDirectory: (directoryName, extensions) => {
-      const repoPath = toRepoRelativeCompilerPath(directoryName, repoRoot);
-      if (repoPath === undefined) return ts.sys.readDirectory(directoryName, extensions);
-      if (isDeterministicExternalRepoDirectory(repoPath)) return ts.sys.readDirectory(directoryName, extensions);
-      const prefix = repoPath.length === 0 ? "" : `${repoPath}/`;
-      const allowedExtensions = new Set(extensions ?? [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".json"]);
-      return sourcePaths
-        .filter((path) => path.startsWith(prefix) && [...allowedExtensions].some((extension) => path.endsWith(extension)))
-        .map((path) => toCompilerFileName(path, repoRoot))
-        .sort();
-    },
-    getSourceFile: (fileName, languageVersion) => {
-      const content = host.readFile(fileName);
-      return content === undefined
-        ? undefined
-        : ts.createSourceFile(fileName, content, languageVersion, true, scriptKindForCompilerFileName(fileName));
-    },
+    fileExists: (fileName) => overlayFileExists(fileName, state),
+    readFile: (fileName) => readOverlayFile(fileName, state),
+    directoryExists: (directoryName) => overlayDirectoryExists(directoryName, state),
+    getDirectories: (directoryName) => overlayDirectories(directoryName, state),
+    readDirectory: (directoryName, extensions) => readOverlayDirectory(directoryName, extensions, state),
+    getSourceFile: (fileName, languageVersion) => createOverlaySourceFile(fileName, languageVersion, host),
     resolveModuleNames: (moduleNames, containingFile, _reusedNames, _redirectedReference, options) =>
-      moduleNames.map((moduleName) => ts.resolveModuleName(moduleName, containingFile, options, host).resolvedModule)
+      moduleNames.map((moduleName) => ts.resolveModuleName(moduleName, containingFile, options, host).resolvedModule),
+    writeFile: (fileName, data, writeByteOrderMark, onError) =>
+      writeIncrementalBuildInfo({ fileName, data, writeByteOrderMark, onError, state })
   };
   return host;
+}
+
+function overlayFileExists(fileName: string, state: OverlayAwareCompilerHostState): boolean {
+  if (isIncrementalBuildInfoFile(fileName, state.normalizedBuildInfoPath)) return ts.sys.fileExists(fileName);
+  if (isTypeScriptLibraryFile(fileName)) return ts.sys.fileExists(fileName);
+  const repoPath = toRepoRelativeCompilerPath(fileName, state.repoRoot);
+  if (repoPath !== undefined) {
+    if (state.sourceByPath.has(repoPath)) return true;
+    return isDeterministicExternalRepoFile(repoPath) && ts.sys.fileExists(fileName);
+  }
+  return ts.sys.fileExists(fileName);
+}
+
+function readOverlayFile(fileName: string, state: OverlayAwareCompilerHostState): string | undefined {
+  if (isIncrementalBuildInfoFile(fileName, state.normalizedBuildInfoPath)) return ts.sys.readFile(fileName);
+  if (isTypeScriptLibraryFile(fileName)) return ts.sys.readFile(fileName);
+  const repoPath = toRepoRelativeCompilerPath(fileName, state.repoRoot);
+  if (repoPath === undefined) return ts.sys.readFile(fileName);
+  const sourceContent = state.sourceByPath.get(repoPath);
+  if (sourceContent !== undefined) return sourceContent;
+  return isDeterministicExternalRepoFile(repoPath) ? ts.sys.readFile(fileName) : undefined;
+}
+
+function overlayDirectoryExists(directoryName: string, state: OverlayAwareCompilerHostState): boolean {
+  const repoPath = toRepoRelativeCompilerPath(directoryName, state.repoRoot);
+  if (repoPath === undefined) return ts.sys.directoryExists?.(directoryName) ?? false;
+  if (repoPath.length === 0 || state.sourcePaths.some((path) => path.startsWith(`${repoPath}/`))) return true;
+  return isDeterministicExternalRepoDirectory(repoPath) && (ts.sys.directoryExists?.(directoryName) ?? false);
+}
+
+function overlayDirectories(directoryName: string, state: OverlayAwareCompilerHostState): string[] {
+  const repoPath = toRepoRelativeCompilerPath(directoryName, state.repoRoot);
+  if (repoPath === undefined) return ts.sys.getDirectories?.(directoryName) ?? [];
+  if (isDeterministicExternalRepoDirectory(repoPath)) return ts.sys.getDirectories?.(directoryName) ?? [];
+  const prefix = repoPath.length === 0 ? "" : `${repoPath}/`;
+  const children = new Set<string>();
+  for (const path of state.sourcePaths) {
+    if (!path.startsWith(prefix)) continue;
+    const rest = path.slice(prefix.length);
+    const child = rest.split("/", 1)[0];
+    if (child !== undefined && rest.includes("/")) children.add(child);
+  }
+  return [...children].sort();
+}
+
+function readOverlayDirectory(
+  directoryName: string,
+  extensions: readonly string[] | undefined,
+  state: OverlayAwareCompilerHostState
+): string[] {
+  const repoPath = toRepoRelativeCompilerPath(directoryName, state.repoRoot);
+  if (repoPath === undefined) return ts.sys.readDirectory(directoryName, extensions);
+  if (isDeterministicExternalRepoDirectory(repoPath)) return ts.sys.readDirectory(directoryName, extensions);
+  const prefix = repoPath.length === 0 ? "" : `${repoPath}/`;
+  const allowedExtensions = new Set(extensions ?? [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".json"]);
+  return state.sourcePaths
+    .filter((path) => path.startsWith(prefix) && [...allowedExtensions].some((extension) => path.endsWith(extension)))
+    .map((path) => toCompilerFileName(path, state.repoRoot))
+    .sort();
+}
+
+function createOverlaySourceFile(
+  fileName: string,
+  languageVersion: ts.ScriptTarget | ts.CreateSourceFileOptions,
+  host: ts.CompilerHost
+): ts.SourceFile | undefined {
+  const content = host.readFile(fileName);
+  return content === undefined
+    ? undefined
+    : versionSourceFile(
+        ts.createSourceFile(fileName, content, languageVersion, true, scriptKindForCompilerFileName(fileName)),
+        content
+      );
+}
+
+function writeIncrementalBuildInfo(args: WriteIncrementalBuildInfoArgs): void {
+  const { fileName, data, writeByteOrderMark, onError, state } = args;
+  if (!isIncrementalBuildInfoFile(fileName, state.normalizedBuildInfoPath)) return;
+  try {
+    ensureDirectory(parentDirectory(fileName));
+    ts.sys.writeFile(fileName, data, writeByteOrderMark);
+  } catch (error) {
+    onError?.(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function typeScriptBuildInfoPath(
+  context: ValidationCheckContext,
+  repoRoot: string,
+  compilerProject: ResolvedTypeScriptCompilerProject,
+  sourceSet: TypeScriptMaterializedSourceSet
+): string | undefined {
+  if (context.runtime.persistentCaches !== "enabled") return undefined;
+  if (context.fileView.overlays.length > 0) return undefined;
+  if (repoRoot === virtualRepoRoot || !repoRoot.startsWith("/")) return undefined;
+  if (sourceSet.files.length === 0 || !sourceSetMatchesDisk(repoRoot, sourceSet)) return undefined;
+  const key = stableJson({
+    configPath: compilerProject.configPath ?? "",
+    rootPaths: compilerProject.rootPaths,
+    supportPaths: compilerProject.supportPaths,
+    options: compilerProject.options
+  });
+  return `${repoRoot}/${typeScriptBuildInfoDirectory}/project-${hashText(key)}.tsbuildinfo`;
+}
+
+function sourceSetMatchesDisk(repoRoot: string, sourceSet: TypeScriptMaterializedSourceSet): boolean {
+  return sourceSet.files.every((file) => ts.sys.readFile(toCompilerFileName(file.path, repoRoot)) === file.content);
+}
+
+function isIncrementalBuildInfoFile(fileName: string, normalizedBuildInfoPath: string | undefined): boolean {
+  return normalizedBuildInfoPath !== undefined && normalizePath(fileName) === normalizedBuildInfoPath;
+}
+
+function versionSourceFile(sourceFile: ts.SourceFile, content: string): ts.SourceFile & { version: string } {
+  return Object.assign(sourceFile, { version: hashText(content) });
+}
+
+function hashText(content: string): string {
+  return ts.sys.createHash?.(content) ?? fallbackHashText(content);
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .filter((entry) => entry[1] !== undefined)
+      .sort((left, right) => left[0].localeCompare(right[0]))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function hasBuildInfoEmitter(builderProgram: ts.BuilderProgram): builderProgram is ts.BuilderProgram & BuildInfoEmitter {
+  return typeof (builderProgram as { emitBuildInfo?: unknown }).emitBuildInfo === "function";
+}
+
+function ensureDirectory(path: string): void {
+  const normalized = stripTrailingSlash(path);
+  if (normalized.length === 0 || ts.sys.directoryExists(normalized)) return;
+  const parent = parentDirectory(normalized);
+  if (parent !== normalized) ensureDirectory(parent);
+  if (!ts.sys.directoryExists(normalized)) ts.sys.createDirectory(normalized);
+}
+
+function parentDirectory(path: string): string {
+  const normalized = stripTrailingSlash(normalizePath(path));
+  const index = normalized.lastIndexOf("/");
+  if (index <= 0) return normalized.startsWith("/") ? "/" : "";
+  return normalized.slice(0, index);
+}
+
+function fallbackHashText(content: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < content.length; index += 1) {
+    hash ^= content.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${content.length.toString(16)}-${(hash >>> 0).toString(16).padStart(8, "0")}`;
 }
 
 function isTypeScriptLibraryFile(fileName: string): boolean {

--- a/packages/validation-typescript/src/syntax-check.ts
+++ b/packages/validation-typescript/src/syntax-check.ts
@@ -1,7 +1,11 @@
 import type { ValidationCheckDefinition } from "@the-open-engine/opcore-validation";
 import type { ValidationDiagnostic } from "@the-open-engine/opcore-contracts";
 import { TYPE_SCRIPT_SYNTAX_CHECK_ID } from "./check-ids.js";
-import { createOverlayAwareTypeScriptProgramIterator, repoSourceFiles } from "./compiler-host.js";
+import {
+  createOverlayAwareTypeScriptProgramIterator,
+  emitTypeScriptProgramBuildInfo,
+  repoSourceFiles
+} from "./compiler-host.js";
 import { typeScriptCheckAdapter, typeScriptCheckOwner, supportedTypeScriptValidationScopes } from "./check-constants.js";
 import { mapTypeScriptDiagnostics } from "./diagnostics.js";
 
@@ -18,10 +22,13 @@ export function createSyntaxCheck(): ValidationCheckDefinition {
         diagnostics.push(
           ...mapTypeScriptDiagnostics(
             "syntax",
-            repoSourceFiles(bundle).flatMap((sourceFile) => bundle.program.getSyntacticDiagnostics(sourceFile)),
+            repoSourceFiles(bundle).flatMap((sourceFile) =>
+              (bundle.builderProgram ?? bundle.program).getSyntacticDiagnostics(sourceFile)
+            ),
             bundle.repoRoot
           )
         );
+        emitTypeScriptProgramBuildInfo(bundle);
       }
       return { diagnostics };
     }

--- a/packages/validation-typescript/src/type-check.ts
+++ b/packages/validation-typescript/src/type-check.ts
@@ -3,7 +3,12 @@ import type { ValidationDiagnostic } from "@the-open-engine/opcore-contracts";
 import ts from "typescript";
 import { TYPE_SCRIPT_TYPES_CHECK_ID } from "./check-ids.js";
 import { typeScriptCheckAdapter, typeScriptCheckOwner, supportedTypeScriptValidationScopes } from "./check-constants.js";
-import { createOverlayAwareTypeScriptProgramIterator, repoSourceFiles, toRepoRelativeCompilerPath } from "./compiler-host.js";
+import {
+  createOverlayAwareTypeScriptProgramIterator,
+  emitTypeScriptProgramBuildInfo,
+  repoSourceFiles,
+  toRepoRelativeCompilerPath
+} from "./compiler-host.js";
 import { mapTypeScriptDiagnostics } from "./diagnostics.js";
 
 export interface CollectTypeScriptSemanticDiagnosticsArgs {
@@ -27,22 +32,24 @@ export function createTypeCheck(): ValidationCheckDefinition {
     run: async (context) => {
       const diagnostics: ValidationDiagnostic[] = [];
       for await (const bundle of createOverlayAwareTypeScriptProgramIterator(context)) {
+        const diagnosticsProvider = bundle.builderProgram ?? bundle.program;
         diagnostics.push(
           ...mapTypeScriptDiagnostics(
             "types",
             [
               ...bundle.configDiagnostics,
-              ...bundle.program.getOptionsDiagnostics(),
-              ...bundle.program.getGlobalDiagnostics()
+              ...diagnosticsProvider.getOptionsDiagnostics(),
+              ...diagnosticsProvider.getGlobalDiagnostics()
             ],
             bundle.repoRoot
           ),
           ...collectTypeScriptSemanticDiagnostics({
             repoRoot: bundle.repoRoot,
             sourceFiles: repoSourceFiles(bundle),
-            getSemanticDiagnostics: (sourceFile) => bundle.program.getSemanticDiagnostics(sourceFile)
+            getSemanticDiagnostics: (sourceFile) => diagnosticsProvider.getSemanticDiagnostics(sourceFile)
           })
         );
+        emitTypeScriptProgramBuildInfo(bundle);
       }
       return { diagnostics };
     }

--- a/packages/validation/src/command-adapter.ts
+++ b/packages/validation/src/command-adapter.ts
@@ -26,6 +26,7 @@ import { createValidationRunner, type CreateValidationRunnerOptions, type Valida
 import { createNodeValidationWorkspace } from "./workspace.js";
 import type { ValidationGraphProviderClient } from "./graph-client.js";
 import type { ValidationWorkspace } from "./scope.js";
+import type { ValidationRuntimePolicy } from "./registry.js";
 import { readFile } from "node:fs/promises";
 
 declare const process: {
@@ -40,6 +41,7 @@ export interface ValidationCommandAdapterOptions {
   graphProviderClient?: ValidationGraphProviderClient;
   clock?: ValidationClock;
   defaultRepoRoot?: string;
+  runtime?: ValidationRuntimePolicy;
 }
 
 export function createCheckCommandAdapter(options: ValidationCommandAdapterOptions = {}): CommandAdapter {
@@ -131,7 +133,8 @@ async function runRequest(
     workspace: workspaceForRequest(request, parsed, options),
     registry: registryForOptions(options),
     graphProviderClient: options.graphProviderClient,
-    clock: options.clock
+    clock: options.clock,
+    runtime: options.runtime
   };
   return createValidationRunner(runnerOptions).runValidation(request);
 }

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -115,7 +115,9 @@ export {
   type ValidationCheckContext,
   type ValidationCheckDefinition,
   type ValidationCheckRegistry,
-  type ValidationCheckResult
+  type ValidationCheckResult,
+  type ValidationPersistentCacheMode,
+  type ValidationRuntimePolicy
 } from "./registry.js";
 export {
   ValidationOverlayConflictError,

--- a/packages/validation/src/registry.ts
+++ b/packages/validation/src/registry.ts
@@ -20,6 +20,13 @@ export interface ValidationCheckContext {
   graphStatus: GraphProviderStatus;
   graph: ValidationGraphQuerySession;
   fileView: ValidationFileView;
+  runtime: ValidationRuntimePolicy;
+}
+
+export type ValidationPersistentCacheMode = "enabled" | "disabled";
+
+export interface ValidationRuntimePolicy {
+  persistentCaches: ValidationPersistentCacheMode;
 }
 
 export interface ValidationCheckResult {

--- a/packages/validation/src/runner.ts
+++ b/packages/validation/src/runner.ts
@@ -28,7 +28,8 @@ import {
   ValidationCheckRegistryError,
   type ValidationCheckDefinition,
   type ValidationCheckRegistry,
-  type ValidationCheckResult
+  type ValidationCheckResult,
+  type ValidationRuntimePolicy
 } from "./registry.js";
 import { defaultValidationGraphProvider, missingGraphStatus, normalizeValidationRequest } from "./request.js";
 import {
@@ -50,6 +51,7 @@ export interface CreateValidationRunnerOptions {
   graphProviderClient?: ValidationGraphProviderClient;
   graphSessionFactory?: ValidationGraphSessionFactory;
   clock?: ValidationClock;
+  runtime?: ValidationRuntimePolicy;
 }
 
 export interface ValidationRunner {
@@ -61,8 +63,14 @@ const systemClock: ValidationClock = {
   isoNow: () => new Date().toISOString()
 };
 
+const defaultRuntimePolicy: ValidationRuntimePolicy = {
+  persistentCaches: "enabled"
+};
+
 type RunnerRuntimeOptions = Required<Pick<CreateValidationRunnerOptions, "workspace" | "registry" | "clock">> &
-  Pick<CreateValidationRunnerOptions, "graphProviderClient" | "graphSessionFactory">;
+  Pick<CreateValidationRunnerOptions, "graphProviderClient" | "graphSessionFactory"> & {
+    runtime: ValidationRuntimePolicy;
+  };
 
 interface CheckExecution {
   runs: ValidationCheckRunSummary[];
@@ -79,6 +87,7 @@ interface ExecuteChecksArgs {
   selectedChecks: readonly ValidationCheckDefinition[];
   totalStartedAt: number;
   clock: ValidationClock;
+  runtime: ValidationRuntimePolicy;
 }
 
 interface SingleCheckOutcome {
@@ -92,11 +101,13 @@ interface SingleCheckOutcome {
 export function createValidationRunner(options: CreateValidationRunnerOptions): ValidationRunner {
   const registry = options.registry ?? createValidationCheckRegistry(options.checks ?? []);
   const clock = options.clock ?? systemClock;
+  const runtime = options.runtime ?? defaultRuntimePolicy;
   return {
     runValidation: (request) => runValidation(request, {
       ...options,
       registry,
-      clock
+      clock,
+      runtime
     })
   };
 }
@@ -144,7 +155,8 @@ async function runPreparedValidation(
       fileView,
       selectedChecks,
       totalStartedAt,
-      clock: options.clock
+      clock: options.clock,
+      runtime: options.runtime
     });
     if (execution.failureResult !== undefined) return execution.failureResult;
     return finalValidationResult(selectedChecks, execution, graph.status, totalStartedAt, options.clock);
@@ -320,7 +332,8 @@ function checkContext(args: ExecuteChecksArgs) {
     scope: args.scope,
     graphStatus: args.graph.status,
     graph: args.graph,
-    fileView: args.fileView
+    fileView: args.fileView,
+    runtime: args.runtime
   };
 }
 

--- a/tests/opcore-facade.test.mjs
+++ b/tests/opcore-facade.test.mjs
@@ -303,6 +303,7 @@ describe("opcore public facade", () => {
       assert.equal(Object.hasOwn(result.validationResult.manifest, "runs"), false);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "skippedChecks"), false);
       assert.equal(result.timing.phases.some((phase) => phase.phase === "validation_typescript_syntax"), true);
+      assert.equal(existsSync(join(fixtureRoot, ".opcore")), false);
     });
   });
 

--- a/tests/validation-typescript.test.mjs
+++ b/tests/validation-typescript.test.mjs
@@ -188,6 +188,211 @@ describe("validation-typescript adapter", () => {
     assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
   });
 
+  it("shares one TypeScript program per project across syntax and type checks in one validation request", async () => {
+    const libraryReads = new Map();
+    const originalReadFile = ts.sys.readFile;
+    ts.sys.readFile = (path, encoding) => {
+      const normalized = path.replaceAll("\\", "/");
+      if (normalized.endsWith("/node_modules/typescript/lib/lib.es2022.full.d.ts")) {
+        libraryReads.set(normalized, (libraryReads.get(normalized) ?? 0) + 1);
+      }
+      return originalReadFile(path, encoding);
+    };
+
+    try {
+      const result = await runner({
+        files: {
+          "apps/web/tsconfig.json": JSON.stringify({
+            compilerOptions: {
+              baseUrl: ".",
+              paths: {
+                "@/*": ["src/*"]
+              }
+            }
+          }),
+          "apps/web/src/index.ts": "import { value } from '@/dep';\nexport const label: string = value;\n",
+          "apps/web/src/dep.ts": "export const value = 'web';\n",
+          "packages/api/tsconfig.json": JSON.stringify({
+            compilerOptions: {
+              baseUrl: ".",
+              paths: {
+                "#/*": ["source/*"]
+              }
+            }
+          }),
+          "packages/api/source/index.ts": "import { count } from '#/dep';\nexport const total: number = count;\n",
+          "packages/api/source/dep.ts": "export const count = 1;\n"
+        }
+      }).runValidation(
+        request({
+          checks: [TYPE_SCRIPT_SYNTAX_CHECK_ID, TYPE_SCRIPT_TYPES_CHECK_ID],
+          scope: {
+            kind: "all"
+          }
+        })
+      );
+
+      const defaultLibReadCount = [...libraryReads.values()].reduce((sum, count) => sum + count, 0);
+      assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
+      assert.equal(defaultLibReadCount, 2);
+    } finally {
+      ts.sys.readFile = originalReadFile;
+    }
+  });
+
+  it("persists and reads TypeScript build info for repeated on-disk validations", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "opcore-validation-ts-build-info-"));
+    try {
+      mkdirSync(join(repo, "src"), { recursive: true });
+      writeFileSync(
+        join(repo, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            strict: true,
+            target: "ES2022"
+          },
+          include: ["src/**/*.ts"]
+        })
+      );
+      writeFileSync(join(repo, "src/dep.ts"), "export const value = 'disk';\n");
+      writeFileSync(join(repo, "src/index.ts"), "import { value } from './dep';\nexport const label: string = value;\n");
+
+      const validation = createValidationRunner({
+        workspace: createNodeValidationWorkspace({ repoRoot: repo }),
+        checks: createTypeScriptValidationChecks()
+      });
+      const validationRequest = request({
+        repo: { repoRoot: repo },
+        checks: [TYPE_SCRIPT_SYNTAX_CHECK_ID, TYPE_SCRIPT_TYPES_CHECK_ID],
+        scope: {
+          kind: "files",
+          files: ["src/index.ts"]
+        }
+      });
+
+      const first = await validation.runValidation(validationRequest);
+      assert.equal(first.status, "passed", JSON.stringify(first.diagnostics, null, 2));
+      assert.equal(listTypeScriptBuildInfoFiles(repo).length, 1);
+
+      let buildInfoReads = 0;
+      const originalReadFile = ts.sys.readFile;
+      ts.sys.readFile = (path, encoding) => {
+        const normalized = path.replaceAll("\\", "/");
+        if (normalized.includes("/.opcore/typescript-build-info/") && normalized.endsWith(".tsbuildinfo")) {
+          buildInfoReads += 1;
+        }
+        return originalReadFile(path, encoding);
+      };
+      try {
+        const second = await validation.runValidation(validationRequest);
+        assert.equal(second.status, "passed", JSON.stringify(second.diagnostics, null, 2));
+      } finally {
+        ts.sys.readFile = originalReadFile;
+      }
+
+      assert.ok(buildInfoReads > 0);
+      assert.equal(listTypeScriptBuildInfoFiles(repo).length, 1);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("honors runtime policy when persistent TypeScript build info is disabled", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "opcore-validation-ts-build-info-disabled-"));
+    try {
+      mkdirSync(join(repo, "src"), { recursive: true });
+      writeFileSync(
+        join(repo, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            strict: true,
+            target: "ES2022"
+          },
+          include: ["src/**/*.ts"]
+        })
+      );
+      writeFileSync(join(repo, "src/index.ts"), "export const value: string = 'disk';\n");
+
+      const validation = createValidationRunner({
+        workspace: createNodeValidationWorkspace({ repoRoot: repo }),
+        checks: createTypeScriptValidationChecks(),
+        runtime: {
+          persistentCaches: "disabled"
+        }
+      });
+
+      const result = await validation.runValidation(
+        request({
+          repo: { repoRoot: repo },
+          checks: [TYPE_SCRIPT_SYNTAX_CHECK_ID, TYPE_SCRIPT_TYPES_CHECK_ID],
+          scope: {
+            kind: "files",
+            files: ["src/index.ts"]
+          }
+        })
+      );
+
+      assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
+      assert.deepEqual(listTypeScriptBuildInfoFiles(repo), []);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps overlay TypeScript programs in memory without writing build info", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "opcore-validation-ts-overlay-"));
+    try {
+      mkdirSync(join(repo, "src"), { recursive: true });
+      writeFileSync(
+        join(repo, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            strict: true,
+            target: "ES2022"
+          },
+          include: ["src/**/*.ts"]
+        })
+      );
+      const sourcePath = join(repo, "src/index.ts");
+      const source = "export const value: string = 'disk';\n";
+      writeFileSync(sourcePath, source);
+
+      const result = await createValidationRunner({
+        workspace: createNodeValidationWorkspace({ repoRoot: repo }),
+        checks: createTypeScriptValidationChecks()
+      }).runValidation(
+        request({
+          repo: { repoRoot: repo },
+          checks: [TYPE_SCRIPT_SYNTAX_CHECK_ID, TYPE_SCRIPT_TYPES_CHECK_ID],
+          scope: {
+            kind: "files",
+            files: ["src/index.ts"]
+          },
+          overlays: [
+            {
+              path: "src/index.ts",
+              action: "write",
+              content: "export const value: string = 1;\n"
+            }
+          ]
+        })
+      );
+
+      assert.equal(result.status, "policy_failure");
+      assert.equal(result.diagnostics.find((diagnostic) => diagnostic.category === "types")?.code, "2322");
+      assert.equal(readFileSync(sourcePath, "utf8"), source);
+      assert.deepEqual(listTypeScriptBuildInfoFiles(repo), []);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("loads project ambient declarations for scoped TypeScript type checks", async () => {
     const temp = mkdtempSync(join(tmpdir(), "opcore-validation-ts-ambient-"));
     try {
@@ -1339,6 +1544,14 @@ function listRepoFiles(root) {
     if (entry.isDirectory()) return listRepoFiles(relative(process.cwd(), absolutePath));
     return relative(process.cwd(), absolutePath).replaceAll("\\", "/");
   });
+}
+
+function listTypeScriptBuildInfoFiles(repo) {
+  const directory = join(repo, ".opcore/typescript-build-info");
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".tsbuildinfo"))
+    .sort();
 }
 
 function graphClient(overrides = {}) {


### PR DESCRIPTION
Reuse overlay-aware TypeScript programs across syntax and type checks in a single validation request. This reduces duplicate compiler setup without changing fileView semantics or writing build info for hypothetical overlays.

Generic boundary:
- Cache keys come from TypeScript project inputs and validation fileView state, not repository identity.
- Overlay validations stay in memory; on-disk incremental state remains limited to disk-backed validations.

Verification:
- `npm run build --workspace @the-open-engine/opcore-validation-typescript`
- `node --test tests/validation-typescript.test.mjs`
- `npm run lint`
- `node packages/opcore/dist/index.js check changed --base origin/main --json`
- `npm run current-tools:validate-changed`
- `git diff --check origin/main`

Closes #148