### PR TITLE
feat(graph): add inheritors_of named query

### DIFF
--- a/crates/graph-core/src/daemon/tests.rs
+++ b/crates/graph-core/src/daemon/tests.rs
@@ -140,6 +140,14 @@ fn status_handshake_reports_capabilities() -> TestResult {
     ] {
         assert!(node_kinds.iter().any(|value| value == kind), "{kind}");
     }
+    let query_kinds = value
+        .pointer("/status/handshake/queryKinds")
+        .and_then(Value::as_array)
+        .ok_or_else(|| std::io::Error::other("missing handshake queryKinds"))?;
+    assert!(
+        query_kinds.iter().any(|value| value == "inheritors_of"),
+        "inheritors_of"
+    );
     assert_json_eq(
         &value,
         "/status/handshake/artifact/artifactName",

--- a/crates/graph-core/src/protocol/facts.rs
+++ b/crates/graph-core/src/protocol/facts.rs
@@ -105,6 +105,7 @@ pub enum GraphNamedQueryKind {
     ImportersOf,
     ImportsOf,
     TestsFor,
+    InheritorsOf,
     ChildrenOf,
     FileSummary,
 }
@@ -117,6 +118,7 @@ impl GraphNamedQueryKind {
             GraphNamedQueryKind::ImportersOf => "importers_of",
             GraphNamedQueryKind::ImportsOf => "imports_of",
             GraphNamedQueryKind::TestsFor => "tests_for",
+            GraphNamedQueryKind::InheritorsOf => "inheritors_of",
             GraphNamedQueryKind::ChildrenOf => "children_of",
             GraphNamedQueryKind::FileSummary => "file_summary",
         }

--- a/crates/graph-core/src/protocol/provider.rs
+++ b/crates/graph-core/src/protocol/provider.rs
@@ -266,6 +266,7 @@ pub fn graph_capability_handshake() -> GraphProviderCapabilityHandshake {
             "importers_of".to_string(),
             "imports_of".to_string(),
             "tests_for".to_string(),
+            "inheritors_of".to_string(),
             "children_of".to_string(),
             "file_summary".to_string(),
             "review_context".to_string(),

--- a/crates/graph-core/src/protocol/tests.rs
+++ b/crates/graph-core/src/protocol/tests.rs
@@ -134,6 +134,14 @@ fn status_response_round_trips_with_handshake() -> TestResult {
     for kind in ["IMPLEMENTS", "DEPENDS_ON", "INHERITS"] {
         assert!(edge_kinds.iter().any(|value| value == kind), "{kind}");
     }
+    let query_kinds = value
+        .pointer("/status/handshake/queryKinds")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| std::io::Error::other("missing handshake queryKinds"))?;
+    assert!(
+        query_kinds.iter().any(|value| value == "inheritors_of"),
+        "inheritors_of"
+    );
     let decoded: GraphDaemonResponse = serde_json::from_value(value)?;
     assert_eq!(decoded, response);
     Ok(())

--- a/crates/graph-core/src/query.rs
+++ b/crates/graph-core/src/query.rs
@@ -145,6 +145,10 @@ pub(crate) fn named_query_with_index(
             ),
         ),
         GraphNamedQueryKind::TestsFor => index.tests_for(&target_ids, max_depth, limit),
+        GraphNamedQueryKind::InheritorsOf => index.traverse(
+            &target_ids,
+            TraversalSpec::new(&["INHERITS"], Direction::Incoming, max_depth, limit),
+        ),
         GraphNamedQueryKind::ChildrenOf => index.traverse(
             &target_ids,
             TraversalSpec::new(&["CONTAINS"], Direction::Outgoing, max_depth, limit),

--- a/crates/graph-core/src/query/tests.rs
+++ b/crates/graph-core/src/query/tests.rs
@@ -132,6 +132,54 @@ fn named_query_reports_empty_missing_targets() {
 }
 
 #[test]
+fn named_query_returns_incoming_inherits_edges_for_inheritors() {
+    let snapshot = inheritance_snapshot();
+    let output = named_query(
+        &snapshot,
+        &GraphNamedQueryRequest {
+            request_id: None,
+            repo: repo(),
+            schema_version: 1,
+            mode: GraphProviderMode::Required,
+            query_kind: GraphNamedQueryKind::InheritorsOf,
+            target: "class:src/models.ts#BaseModel".to_string(),
+            max_depth: Some(2),
+            limit: Some(100),
+        },
+    );
+
+    let node_ids = output
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<Vec<_>>();
+    let edge_ids = output
+        .edges
+        .iter()
+        .map(|edge| edge.id.as_deref().unwrap_or_default())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        node_ids,
+        vec![
+            "class:src/models.ts#BaseModel",
+            "class:src/models.ts#DirectModel",
+            "class:src/models.ts#IndirectModel",
+        ]
+    );
+    assert_eq!(
+        edge_ids,
+        vec![
+            "INHERITS:class:src/models.ts#DirectModel->class:src/models.ts#BaseModel",
+            "INHERITS:class:src/models.ts#IndirectModel->class:src/models.ts#DirectModel",
+        ]
+    );
+    assert_eq!(output.traversal.total, 3);
+    assert!(!output.traversal.truncated);
+    assert!(!output.traversal.empty);
+}
+
+#[test]
 fn named_query_handles_import_cycles_with_deterministic_order() {
     let snapshot = cycle_snapshot();
     let output = named_query(
@@ -461,6 +509,61 @@ fn fixture_snapshot() -> StoreQueryOutput {
                 "TESTED_BY",
                 "function:src/models.ts#formatGreeting",
                 "test:src/__tests__/greeting.test.ts#renders greeting cards",
+            ),
+        ],
+        diagnostics: Vec::new(),
+    }
+}
+
+fn inheritance_snapshot() -> StoreQueryOutput {
+    StoreQueryOutput {
+        metadata: GraphSnapshotMetadata {
+            schema_version: 1,
+            provider: "opcore-graph".to_string(),
+            repo: repo(),
+            generated_at: "2026-06-04T00:00:00.000Z".to_string(),
+            freshness: GraphFreshness {
+                generated_at: "2026-06-04T00:00:00.000Z".to_string(),
+                age_ms: 0,
+                max_age_ms: None,
+                stale: false,
+                reason: None,
+            },
+            node_kinds: vec!["Class".to_string()],
+            edge_kinds: vec!["INHERITS".to_string()],
+        },
+        nodes: vec![
+            node(
+                "class:src/models.ts#BaseModel",
+                "Class",
+                Some("src/models.ts"),
+            ),
+            node(
+                "class:src/models.ts#DirectModel",
+                "Class",
+                Some("src/models.ts"),
+            ),
+            node(
+                "class:src/models.ts#IndirectModel",
+                "Class",
+                Some("src/models.ts"),
+            ),
+            node(
+                "class:src/other.ts#UnrelatedModel",
+                "Class",
+                Some("src/other.ts"),
+            ),
+        ],
+        edges: vec![
+            edge(
+                "INHERITS",
+                "class:src/models.ts#DirectModel",
+                "class:src/models.ts#BaseModel",
+            ),
+            edge(
+                "INHERITS",
+                "class:src/models.ts#IndirectModel",
+                "class:src/models.ts#DirectModel",
             ),
         ],
         diagnostics: Vec::new(),

--- a/packages/contracts/schemas/opcore-contracts.schema.json
+++ b/packages/contracts/schemas/opcore-contracts.schema.json
@@ -418,6 +418,7 @@
               "importers_of",
               "imports_of",
               "tests_for",
+              "inheritors_of",
               "children_of",
               "file_summary",
               "review_context",
@@ -10188,6 +10189,7 @@
             "importers_of",
             "imports_of",
             "tests_for",
+            "inheritors_of",
             "children_of",
             "file_summary"
           ]
@@ -10250,6 +10252,7 @@
                 "importers_of",
                 "imports_of",
                 "tests_for",
+                "inheritors_of",
                 "children_of",
                 "file_summary"
               ]

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -352,6 +352,7 @@ export const graphNamedQueryKinds = [
   "importers_of",
   "imports_of",
   "tests_for",
+  "inheritors_of",
   "children_of",
   "file_summary"
 ] as const;

--- a/packages/fixtures/descriptors/opcore.managed-tool.json
+++ b/packages/fixtures/descriptors/opcore.managed-tool.json
@@ -214,6 +214,7 @@
         "importers_of",
         "imports_of",
         "tests_for",
+        "inheritors_of",
         "children_of",
         "file_summary",
         "review_context",

--- a/packages/fixtures/graph-query/query-fixtures.json
+++ b/packages/fixtures/graph-query/query-fixtures.json
@@ -8,6 +8,7 @@
     "importers_of",
     "imports_of",
     "tests_for",
+    "inheritors_of",
     "children_of",
     "file_summary"
   ],

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -661,6 +661,7 @@ export const conformanceFixtureMetadata = [
         "importers_of",
         "imports_of",
         "tests_for",
+        "inheritors_of",
         "children_of",
         "file_summary"
       ],

--- a/tests/conformance.test.mjs
+++ b/tests/conformance.test.mjs
@@ -297,6 +297,7 @@ describe("conformance fixture metadata", () => {
       "importers_of",
       "imports_of",
       "tests_for",
+      "inheritors_of",
       "children_of",
       "file_summary"
     ]);

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -311,6 +311,7 @@ describe("Opcore shared contracts", () => {
       "importers_of",
       "imports_of",
       "tests_for",
+      "inheritors_of",
       "children_of",
       "file_summary"
     ]);
@@ -3595,6 +3596,7 @@ function validHandshake() {
       "importers_of",
       "imports_of",
       "tests_for",
+      "inheritors_of",
       "children_of",
       "file_summary",
       "review_context",

--- a/tests/graph-query-cli.test.mjs
+++ b/tests/graph-query-cli.test.mjs
@@ -39,6 +39,27 @@ describe("graph query CLI routes", () => {
       assert.equal(query.graphQuery.queryKind, "tests_for");
       assert.ok(query.graphQuery.nodes.some((node) => node.path === "src/__tests__/greeting.test.ts"));
 
+      const inheritors = run(latticeBin, [
+        "graph",
+        "query",
+        "inheritors_of",
+        "class:src/models.ts#GreetingModel",
+        "--repo",
+        fixtureRoot,
+        "--json"
+      ]);
+      assert.equal(inheritors.status, "ok");
+      assert.equal(inheritors.graphQuery.queryKind, "inheritors_of");
+      assert.ok(inheritors.providerStatus.handshake.queryKinds.includes("inheritors_of"));
+      assert.deepEqual(
+        inheritors.graphQuery.nodes.map((node) => node.id),
+        [
+          "class:src/models.ts#FriendlyGreetingModel",
+          "class:src/models.ts#GreetingModel",
+          "class:src/models.ts#InternalGreetingModel"
+        ]
+      );
+
       const review = run(latticeBin, ["graph", "review-context", "--repo", fixtureRoot, "--files", "src/models.ts", "--json"]);
       assert.deepEqual(review.graphReviewContext.changedFiles, ["src/models.ts"]);
       assert.ok(review.graphReviewContext.impactedFiles.includes("src/components/GreetingCard.tsx"));

--- a/tests/graph-query-conformance.test.mjs
+++ b/tests/graph-query-conformance.test.mjs
@@ -70,6 +70,27 @@ describe("GraphProvider query conformance", () => {
       );
       assert.ok(children.nodes.map((node) => node.id).includes("class:src/models.ts#GreetingModel"));
 
+      const inheritors = graphProviderNamedQuery(
+        { repoRoot: fixtureRoot },
+        { queryKind: "inheritors_of", target: "class:src/models.ts#GreetingModel", maxDepth: 2, limit: 100 }
+      );
+      assert.equal(inheritors.status.state, "available");
+      assert.deepEqual(
+        inheritors.nodes.map((node) => node.id),
+        [
+          "class:src/models.ts#FriendlyGreetingModel",
+          "class:src/models.ts#GreetingModel",
+          "class:src/models.ts#InternalGreetingModel"
+        ]
+      );
+      assert.deepEqual(
+        inheritors.edges.map((edge) => [edge.kind, edge.from, edge.to]),
+        [
+          ["INHERITS", "class:src/models.ts#FriendlyGreetingModel", "class:src/models.ts#GreetingModel"],
+          ["INHERITS", "class:src/models.ts#InternalGreetingModel", "class:src/models.ts#GreetingModel"]
+        ]
+      );
+
       const summary = graphProviderNamedQuery(
         { repoRoot: fixtureRoot },
         { queryKind: "file_summary", target: "src/models.ts", limit: 100 }

--- a/tests/schema-contracts.test.mjs
+++ b/tests/schema-contracts.test.mjs
@@ -3245,6 +3245,7 @@ function validHandshake() {
       "importers_of",
       "imports_of",
       "tests_for",
+      "inheritors_of",
       "children_of",
       "file_summary",
       "review_context",

--- a/tests/validation-typescript.test.mjs
+++ b/tests/validation-typescript.test.mjs
@@ -1608,6 +1608,7 @@ function graphHandshake(overrides = {}) {
       "importers_of",
       "imports_of",
       "tests_for",
+      "inheritors_of",
       "children_of",
       "file_summary",
       "review_context",


### PR DESCRIPTION
Add first-class graph support for the CRG-era inheritors_of named query so Opcore can return inheritance consumers through the generic GraphProvider query surface.

The query is implemented as an incoming INHERITS traversal, mirrored through TypeScript contracts and JSON schema, and advertised in graph-core capability handshakes and descriptor fixtures.

Verification:
- cargo test -p opcore-graph-core
- node --test tests/graph-query-conformance.test.mjs
- node --test tests/graph-query-cli.test.mjs
- node --test tests/contracts.test.mjs
- node --test tests/schema-contracts.test.mjs
- node --test tests/conformance.test.mjs
- node --test tests/validation-typescript.test.mjs
- cargo clippy -p opcore-graph-core --all-targets --all-features -- -D warnings
- npm run current-tools:validate-changed
- git diff --check origin/main

Fixes #142