### PR TITLE
feat(validation-typescript): detect import cycles

### DIFF
--- a/packages/asp-provider/src/mapping.ts
+++ b/packages/asp-provider/src/mapping.ts
@@ -1,6 +1,7 @@
 import type {
   CommandTiming,
   CommandTimingPhase,
+  GraphProviderStatus,
   GraphProviderMode,
   HypotheticalOverlay,
   ValidationDiagnostic,
@@ -39,6 +40,7 @@ import {
 const providerSource = OPCORE_PROVIDER_ID;
 const capabilityVersion = "check/0.1";
 const supportedComparison = "all";
+const partiallyGraphBackedChecks = new Set(["typescript.import-graph"]);
 let firstAssessmentTiming = true;
 
 export function initializeResult(params: InitializeParams): JsonObject {
@@ -273,7 +275,7 @@ function assessmentFromValidationResult(args: {
   readBlobIds: readonly string[];
   timing: CommandTiming;
 }): Assessment {
-  const resultDegradations = validationCoverageDegradations(args.validationResult);
+  const resultDegradations = validationCoverageDegradations(args.validationResult, args.selectedIds);
   const degraded = uniqueDegradations([...args.mappingDegradations, ...resultDegradations.degraded]);
   const unsupported = uniqueDegradations(resultDegradations.unsupported);
   const status = assessmentStatus(args.validationResult.status, degraded, unsupported);
@@ -388,7 +390,7 @@ function sanitizeCode(code: string): string {
   return code.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "diagnostic";
 }
 
-function validationCoverageDegradations(result: ValidationResult): {
+function validationCoverageDegradations(result: ValidationResult, selectedIds: readonly string[]): {
   degraded: readonly ProviderCoverageDegradation[];
   unsupported: readonly ProviderCoverageDegradation[];
 } {
@@ -415,6 +417,17 @@ function validationCoverageDegradations(result: ValidationResult): {
     degraded.push(entry);
     if (reason === "unsupported") unsupported.push(entry);
   }
+  if (result.graphStatus !== undefined && result.graphStatus.state !== "available") {
+    for (const checkId of selectedIds) {
+      if (!partiallyGraphBackedChecks.has(checkId)) continue;
+      degraded.push({
+        source: providerSource,
+        reason: "unavailable",
+        requirement: checkId,
+        detail: graphStatusMessage(result.graphStatus)
+      });
+    }
+  }
   if (result.status !== "passed" && result.status !== "policy_failure") {
     const reason = result.status === "unsupported_request" ? "unsupported" : result.status === "skipped" ? "incomplete" : "error";
     const entry = {
@@ -427,6 +440,11 @@ function validationCoverageDegradations(result: ValidationResult): {
     if (reason === "unsupported") unsupported.push(entry);
   }
   return { degraded, unsupported };
+}
+
+function graphStatusMessage(status: GraphProviderStatus): string {
+  if ("failure" in status) return status.failure.message;
+  return status.message ?? `Graph provider is not available: ${status.state}`;
 }
 
 function comparisonDegradations(requested: string): readonly ProviderCoverageDegradation[] {

--- a/packages/validation-typescript/src/import-graph-check.ts
+++ b/packages/validation-typescript/src/import-graph-check.ts
@@ -1,9 +1,9 @@
 import type { GraphFactEdge, ValidationDiagnostic } from "@the-open-engine/opcore-contracts";
-import type { ValidationCheckDefinition } from "@the-open-engine/opcore-validation";
+import type { ValidationCheckContext, ValidationCheckDefinition } from "@the-open-engine/opcore-validation";
+import { ValidationGraphProviderError } from "@the-open-engine/opcore-validation";
 import { TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID } from "./check-ids.js";
 import { typeScriptCheckAdapter, typeScriptCheckOwner, supportedTypeScriptValidationScopes } from "./check-constants.js";
-import { importGraphRequirements } from "./graph-requirements.js";
-import { materializeTypeScriptSources, toFileNodeId } from "./source-files.js";
+import { materializeTypeScriptSources, toFileNodeId, type TypeScriptRelativeImport } from "./source-files.js";
 
 export function createImportGraphCheck(): ValidationCheckDefinition {
   return {
@@ -12,22 +12,39 @@ export function createImportGraphCheck(): ValidationCheckDefinition {
     adapter: typeScriptCheckAdapter,
     defaultSeverity: "warning",
     supportedScopes: supportedTypeScriptValidationScopes,
-    requiresGraph: true,
-    graphRequirements: importGraphRequirements,
+    requiresGraph: false,
     run: async (context) => {
-      const [sourceSet, edges] = await Promise.all([materializeTypeScriptSources(context), context.graph.importsFrom()]);
-      const diagnostics = sourceSet.relativeImports
-        .filter((relativeImport) => !edges.some((edge) => matchesDirectedFileEdge(edge, relativeImport.fromPath, relativeImport.resolvedPath)))
-        .map((relativeImport): ValidationDiagnostic => ({
-          category: "graph",
-          severity: "warning",
-          path: relativeImport.fromPath,
-          code: "TS_IMPORT_GRAPH_MISSING_EDGE",
-          message: `Missing IMPORTS_FROM graph edge for ${relativeImport.fromPath} -> ${relativeImport.resolvedPath}`
-        }));
+      const sourceSet = await materializeTypeScriptSources(context);
+      const diagnostics = [
+        ...cycleDiagnostics(sourceSet.relativeImports),
+        ...(await retainedMissingEdgeDiagnostics(context, sourceSet.relativeImports))
+      ].sort(compareDiagnostics);
       return { diagnostics };
     }
   };
+}
+
+async function retainedMissingEdgeDiagnostics(
+  context: ValidationCheckContext,
+  relativeImports: readonly TypeScriptRelativeImport[]
+): Promise<readonly ValidationDiagnostic[]> {
+  if (context.graphStatus.state !== "available" || !context.graph.queryCapable) return [];
+  let edges: readonly GraphFactEdge[];
+  try {
+    edges = await context.graph.importsFrom();
+  } catch (error) {
+    if (error instanceof ValidationGraphProviderError && context.request.graph.mode !== "required") return [];
+    throw error;
+  }
+  return relativeImports
+    .filter((relativeImport) => !edges.some((edge) => matchesDirectedFileEdge(edge, relativeImport.fromPath, relativeImport.resolvedPath)))
+    .map((relativeImport): ValidationDiagnostic => ({
+      category: "graph",
+      severity: "warning",
+      path: relativeImport.fromPath,
+      code: "TS_IMPORT_GRAPH_MISSING_EDGE",
+      message: `Missing IMPORTS_FROM graph edge for ${relativeImport.fromPath} -> ${relativeImport.resolvedPath}`
+    }));
 }
 
 function matchesDirectedFileEdge(edge: GraphFactEdge, fromPath: string, toPath: string): boolean {
@@ -36,4 +53,80 @@ function matchesDirectedFileEdge(edge: GraphFactEdge, fromPath: string, toPath: 
 
 function endpointAliases(path: string): ReadonlySet<string> {
   return new Set([path, toFileNodeId(path)]);
+}
+
+interface ImportGraphEdge {
+  from: string;
+  to: string;
+}
+
+function cycleDiagnostics(relativeImports: readonly TypeScriptRelativeImport[]): readonly ValidationDiagnostic[] {
+  return findCycles(relativeImports.map((relativeImport) => ({ from: relativeImport.fromPath, to: relativeImport.resolvedPath }))).map(
+    (cycle): ValidationDiagnostic => ({
+      category: "graph",
+      severity: "warning",
+      path: cycle[0],
+      code: "TS_IMPORT_GRAPH_CYCLE",
+      message: `TypeScript import cycle detected: ${cycle.join(" -> ")}`
+    })
+  );
+}
+
+function findCycles(edges: readonly ImportGraphEdge[]): readonly (readonly string[])[] {
+  const graph = adjacencyList(edges);
+  const cycles = new Map<string, readonly string[]>();
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (node: string): void => {
+    if (visiting.has(node)) {
+      const index = stack.indexOf(node);
+      if (index !== -1) {
+        const cycle = canonicalCycle([...stack.slice(index), node]);
+        cycles.set(cycle.join("\0"), cycle);
+      }
+      return;
+    }
+    if (visited.has(node)) return;
+    visiting.add(node);
+    stack.push(node);
+    for (const target of graph.get(node) ?? []) visit(target);
+    stack.pop();
+    visiting.delete(node);
+    visited.add(node);
+  };
+
+  for (const node of graph.keys()) visit(node);
+  return [...cycles.values()].sort((left, right) => left.join("\0").localeCompare(right.join("\0")));
+}
+
+function adjacencyList(edges: readonly ImportGraphEdge[]): ReadonlyMap<string, readonly string[]> {
+  const graph = new Map<string, Set<string>>();
+  for (const edge of edges) {
+    const targets = graph.get(edge.from) ?? new Set<string>();
+    targets.add(edge.to);
+    graph.set(edge.from, targets);
+    if (!graph.has(edge.to)) graph.set(edge.to, new Set());
+  }
+  return new Map(
+    [...graph.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([node, targets]) => [node, [...targets].sort()] as const)
+  );
+}
+
+function canonicalCycle(cycle: readonly string[]): readonly string[] {
+  const nodes = cycle.slice(0, -1);
+  const rotations = nodes.map((_, index) => [...nodes.slice(index), ...nodes.slice(0, index)]);
+  const [canonical] = rotations.sort((left, right) => left.join("\0").localeCompare(right.join("\0")));
+  return [...canonical, canonical[0]];
+}
+
+function compareDiagnostics(left: ValidationDiagnostic, right: ValidationDiagnostic): number {
+  return (
+    (left.path ?? "").localeCompare(right.path ?? "") ||
+    (left.code ?? "").localeCompare(right.code ?? "") ||
+    left.message.localeCompare(right.message)
+  );
 }

--- a/tests/validation-typescript.test.mjs
+++ b/tests/validation-typescript.test.mjs
@@ -33,7 +33,7 @@ describe("validation-typescript adapter", () => {
       ]
     );
     assert.equal(registry.byId.get(TYPE_SCRIPT_SYNTAX_CHECK_ID)?.requiresGraph, false);
-    assert.equal(registry.byId.get(TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID)?.requiresGraph, true);
+    assert.equal(registry.byId.get(TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID)?.requiresGraph, false);
   });
 
   it("reports syntax diagnostics from overlay after-state content", async () => {
@@ -634,12 +634,54 @@ describe("validation-typescript adapter", () => {
     assert.equal(result.status, "passed");
     assert.deepEqual(
       result.manifest.runs.map((run) => run.checkId),
-      [TYPE_SCRIPT_SYNTAX_CHECK_ID, TYPE_SCRIPT_TYPES_CHECK_ID]
+      [TYPE_SCRIPT_SYNTAX_CHECK_ID, TYPE_SCRIPT_TYPES_CHECK_ID, TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID]
     );
     assert.deepEqual(
       result.manifest.skippedChecks.map((skip) => skip.checkId),
-      [TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID, TYPE_SCRIPT_DEAD_CODE_CHECK_ID, TYPE_SCRIPT_RELEVANT_TESTS_CHECK_ID]
+      [TYPE_SCRIPT_DEAD_CODE_CHECK_ID, TYPE_SCRIPT_RELEVANT_TESTS_CHECK_ID]
     );
+  });
+
+  it("reports one canonical TypeScript relative import cycle without a graph provider", async () => {
+    const result = await runner({
+      files: {
+        "src/a.ts": "import { b } from './b';\nexport const a = b;\n",
+        "src/b.ts": "import { a } from './a';\nexport const b = a;\n",
+        "src/index.ts": "import { a } from './a';\nexport const value = a;\n"
+      }
+    }).runValidation(
+      request({
+        checks: [TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID]
+      })
+    );
+
+    assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
+    assert.deepEqual(result.diagnostics, [
+      {
+        category: "graph",
+        severity: "warning",
+        path: "src/a.ts",
+        code: "TS_IMPORT_GRAPH_CYCLE",
+        message: "TypeScript import cycle detected: src/a.ts -> src/b.ts -> src/a.ts"
+      }
+    ]);
+  });
+
+  it("does not report TypeScript import cycles for an acyclic relative import graph", async () => {
+    const result = await runner({
+      files: {
+        "src/a.ts": "import { b } from './b';\nexport const a = b;\n",
+        "src/b.ts": "export const b = 1;\n",
+        "src/index.ts": "import { a } from './a';\nexport const value = a;\n"
+      }
+    }).runValidation(
+      request({
+        checks: [TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID]
+      })
+    );
+
+    assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
+    assert.deepEqual(result.diagnostics, []);
   });
 
   it("fails closed for required graph provider failure states", async () => {
@@ -1431,7 +1473,7 @@ describe("validation-typescript adapter", () => {
       })
     }).runValidation(
       request({
-        checks: [TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID],
+        checks: [TYPE_SCRIPT_DEAD_CODE_CHECK_ID],
         graph: {
           mode: "required",
           provider: "opcore-graph"
@@ -1443,7 +1485,37 @@ describe("validation-typescript adapter", () => {
     assert.equal(result.failure.category, "provider_failure");
   });
 
-  it("batches graph requirements without per-file provider calls", async () => {
+  it("maps required TypeScript import-graph query failures to runner provider_failure", async () => {
+    const result = await runner({
+      files: {
+        "src/a.ts": "import { b } from './b';\nexport const a = b;\n",
+        "src/b.ts": "export const b = 1;\n"
+      },
+      graphProviderClient: graphClient({
+        status: (validationRequest) => availableStatus(validationRequest.graph.mode, validationRequest.repo),
+        factQuery: () => ({
+          status: graphFailure("error", "query_failed", "required")
+        })
+      })
+    }).runValidation(
+      request({
+        checks: [TYPE_SCRIPT_IMPORT_GRAPH_CHECK_ID],
+        scope: {
+          kind: "files",
+          files: ["src/a.ts", "src/b.ts"]
+        },
+        graph: {
+          mode: "required",
+          provider: "opcore-graph"
+        }
+      })
+    );
+
+    assert.equal(result.status, "provider_failure");
+    assert.equal(result.failure.category, "provider_failure");
+  });
+
+  it("queries retained TypeScript import graph edges once without per-file provider calls", async () => {
     const factQueries = [];
     const files = Object.fromEntries(
       Array.from({ length: 100 }, (_, index) => [
@@ -1469,12 +1541,11 @@ describe("validation-typescript adapter", () => {
     );
 
     assert.equal(result.status, "passed");
-    assert.equal(factQueries.length, 2);
+    assert.equal(factQueries.length, 1);
     assert.deepEqual(factQueries[0].selector, {
       kind: "edges",
       edgeKinds: ["IMPORTS_FROM"]
     });
-    assert.equal(factQueries[1].selector.ids.length, 100);
   });
 });
 


### PR DESCRIPTION
Closes #146.

## Problem

`typescript.import-graph` skipped entirely when the graph provider was unavailable, so TypeScript relative import cycles had no adapter-level coverage.

## Approach

- Detect cycles from materialized TypeScript relative imports without requiring graph provider access.
- Keep retained `IMPORTS_FROM` missing-edge comparison when a graph provider is available.
- Cover `a -> b -> a` as one canonical cycle and acyclic imports as no cycle diagnostics.

## Verification

- `npm run setup:tools`
- `npm run build`
- `node --test tests/validation-typescript.test.mjs`
- `npm run lint`
- `npm_config_cache=/private/tmp/opcore-npm-cache npm run pack:check`
- `npm run current-tools:validate-changed`

## Retained Current-Tool Comparison

No direct CRG/CIX equivalent exists for this adapter-level TypeScript import-cycle check. The closest retained comparison is the changed-file current-tool gate, which passed and is non-blocking for this specific cycle diagnostic because the new behavior runs inside `typescript.import-graph` without a graph provider dependency.