### PR TITLE
fix(graph): bound sidecar stderr diagnostics

### DIFF
--- a/packages/graph/src/node-shims.d.ts
+++ b/packages/graph/src/node-shims.d.ts
@@ -66,7 +66,9 @@ declare module "node:fs" {
   export function openSync(path: string, flags: string): number;
   export function readFileSync(path: string): Uint8Array;
   export function readFileSync(path: string, encoding: "utf8"): string;
+  export function readSync(fd: number, buffer: Uint8Array, offset: number, length: number, position: number): number;
   export function rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void;
+  export function statSync(path: string): { size: number; isFile: () => boolean };
 }
 
 declare module "node:os" {

--- a/packages/graph/src/sidecar.ts
+++ b/packages/graph/src/sidecar.ts
@@ -9,7 +9,7 @@ import type {
 } from "@the-open-engine/opcore-contracts";
 import { validateGraphDaemonResponse, validateGraphWatchLifecycle } from "@the-open-engine/opcore-contracts";
 import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { closeSync, existsSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { closeSync, existsSync, mkdtempSync, openSync, readFileSync, readSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ResolvedGraphCoreArtifact } from "./artifact.js";
@@ -18,6 +18,8 @@ import { providerFailureStatus, resolveGraphCoreArtifact, schemaMismatchStatus }
 const GRAPH_CORE_PIPELINE_TIMEOUT_MS = 120_000;
 const GRAPH_CORE_QUERY_TIMEOUT_MS = 30_000;
 const GRAPH_CORE_WATCH_ONCE_TIMEOUT_MS = 120_000;
+const GRAPH_CORE_FAILURE_STDERR_EDGE_CHARS = 64 * 1024;
+const GRAPH_CORE_FAILURE_STDERR_MAX_CHARS = GRAPH_CORE_FAILURE_STDERR_EDGE_CHARS * 2;
 
 declare const process: {
   kill(pid: number, signal?: 0): boolean;
@@ -162,7 +164,7 @@ function spawnGraphCoreSidecarProcess(
     return {
       ...result,
       stdout: readFileSync(stdoutPath, "utf8"),
-      stderr: readFileSync(stderrPath, "utf8")
+      stderr: readBoundedSidecarStderr(stderrPath)
     };
   } finally {
     if (stdoutFd !== undefined) closeSync(stdoutFd);
@@ -331,6 +333,30 @@ function processFailureStatus(result: SpawnSyncReturns): GraphProviderStatus | u
     );
   }
   return undefined;
+}
+
+function readBoundedSidecarStderr(path: string): string {
+  const size = statSync(path).size;
+  if (size <= GRAPH_CORE_FAILURE_STDERR_MAX_CHARS) return readFileSync(path, "utf8");
+  const head = readFileWindow(path, 0, GRAPH_CORE_FAILURE_STDERR_EDGE_CHARS);
+  const tail = readFileWindow(path, size - GRAPH_CORE_FAILURE_STDERR_EDGE_CHARS, GRAPH_CORE_FAILURE_STDERR_EDGE_CHARS);
+  const omitted = size - GRAPH_CORE_FAILURE_STDERR_MAX_CHARS;
+  return [
+    head,
+    `[stderr truncated: ${omitted} bytes omitted]`,
+    tail
+  ].join("\n");
+}
+
+function readFileWindow(path: string, position: number, length: number): string {
+  const fd = openSync(path, "r");
+  try {
+    const buffer = new Uint8Array(length);
+    const bytesRead = readSync(fd, buffer, 0, length, position);
+    return new TextDecoder().decode(buffer.slice(0, bytesRead));
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function firstStdoutLine(stdout: string): string | undefined {

--- a/tests/graph-sidecar-transport.test.mjs
+++ b/tests/graph-sidecar-transport.test.mjs
@@ -40,6 +40,40 @@ describe("graph sidecar transport", () => {
     }
   });
 
+  it("bounds large stderr from failed sidecars while preserving diagnostics", () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-graph-sidecar-large-stderr-"));
+    try {
+      const executablePath = join(temp, "opcore-graph-core");
+      const headMarker = "sidecar stderr head marker";
+      const tailMarker = "sidecar stderr tail marker";
+      writeSidecarStub(executablePath, [
+        `process.stderr.write(${JSON.stringify(headMarker)} + "\\n");`,
+        `process.stderr.write("x".repeat(1024 * 1024 + 128));`,
+        `process.stderr.write("\\n" + ${JSON.stringify(tailMarker)} + "\\n");`,
+        "process.exit(42);"
+      ]);
+
+      const result = invokeResolvedGraphCoreSidecar(testArtifact(temp, executablePath), {
+        protocol: "opcore.graph.daemon",
+        requestId: "large-stderr",
+        schemaVersion: 1,
+        operation: "status",
+        repo: {
+          repoRoot: temp
+        }
+      });
+
+      assert.equal(result.status.state, "daemon_unavailable");
+      assert.match(result.status.failure.message, /graph-core sidecar exited 42/);
+      assert.match(result.status.failure.message, new RegExp(headMarker));
+      assert.match(result.status.failure.message, new RegExp(tailMarker));
+      assert.match(result.status.failure.message, /\[stderr truncated: \d+ bytes omitted\]/);
+      assert.ok(result.status.failure.message.length < 140000, "failure message should not embed full sidecar stderr");
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   it("allows pipeline sidecars to run longer than the legacy five second timeout", { timeout: 15000 }, () => {
     const temp = mkdtempSync(join(tmpdir(), "opcore-graph-sidecar-timeout-"));
     try {


### PR DESCRIPTION
Problem
- Graph-core sidecar transport avoids Node spawnSync buffer failures for large stdout/stderr by using file-backed stdio, but failed sidecars still copied full stderr into GraphProvider failure messages.
- A noisy child process could turn a transport failure response into a multi-megabyte payload.

Approach
- Bound sidecar stderr in failure messages to the first and last 64 KiB with an omitted-character count.
- Add a regression stub that writes more than 1 MiB to stderr, exits nonzero, and verifies the failure remains bounded while preserving head and tail diagnostics.
- Keep the behavior generic to Opcore graph-core sidecars; no repo-specific paths or settings.

Verification
- npm run build
- node --test tests/graph-sidecar-transport.test.mjs
- node --test tests/graph-core-artifact.test.mjs tests/graph-pipeline-cli.test.mjs tests/graph-serve-transport.test.mjs
- npm run lint
- npm_config_cache=/private/tmp/opcore-npm-cache npm run pack:check
- npm run current-tools:validate-changed
- Current CRG comparison: built, searched, and queried the Wave 1 fixture successfully. This is only coarse current-tool evidence that graphing/querying works; it does not exercise the Node sidecar spawnSync buffering path.

Refs #135