### PR TITLE
feat(validation-typescript): widen dead-code graph checks

### DIFF
--- a/packages/validation-typescript/src/dead-code-check.ts
+++ b/packages/validation-typescript/src/dead-code-check.ts
@@ -1,9 +1,14 @@
-import type { GraphFactEdge, GraphFactNode, JsonValue, ValidationDiagnostic } from "@the-open-engine/opcore-contracts";
+import type { GraphEdgeKind, GraphFactEdge, GraphFactNode, JsonValue, ValidationDiagnostic } from "@the-open-engine/opcore-contracts";
 import type { ValidationCheckDefinition } from "@the-open-engine/opcore-validation";
 import { TYPE_SCRIPT_DEAD_CODE_CHECK_ID } from "./check-ids.js";
 import { typeScriptCheckAdapter, typeScriptCheckOwner, supportedTypeScriptValidationScopes } from "./check-constants.js";
 import { deadCodeGraphRequirements } from "./graph-requirements.js";
 import { materializeTypeScriptSources } from "./source-files.js";
+
+const callEdgeKinds = ["CALLS"] as const satisfies readonly GraphEdgeKind[];
+const fileReachabilityEdgeKinds = ["CONTAINS", "IMPORTS_FROM"] as const satisfies readonly GraphEdgeKind[];
+const typeReferenceEdgeKinds = ["INHERITS", "IMPLEMENTS"] as const satisfies readonly GraphEdgeKind[];
+const deadCodeEdgeKinds = [...callEdgeKinds, ...fileReachabilityEdgeKinds, ...typeReferenceEdgeKinds] as const satisfies readonly GraphEdgeKind[];
 
 export function createDeadCodeCheck(): ValidationCheckDefinition {
   return {
@@ -16,15 +21,32 @@ export function createDeadCodeCheck(): ValidationCheckDefinition {
     graphRequirements: deadCodeGraphRequirements,
     run: async (context) => {
       const sourceSet = await materializeTypeScriptSources(context);
-      const [symbolFacts, calls, fileNodes] = await Promise.all([
+      const [symbolFacts, edges, fileNodes] = await Promise.all([
         context.graph.facts({ kind: "symbols" }),
-        context.graph.calls(),
+        context.graph.edgesByKind(deadCodeEdgeKinds),
         context.graph.fileNodes(sourceSet.rootPaths)
       ]);
+      const calls = edges.filter((edge) => edge.kind === "CALLS");
+      const contains = edges.filter((edge) => edge.kind === "CONTAINS");
+      const importsFrom = edges.filter((edge) => edge.kind === "IMPORTS_FROM");
+      const typeReferences = edges.filter((edge) => isTypeReferenceEdge(edge));
       const scopedPaths = new Set(sourceSet.rootPaths);
       const scopedSymbols = symbolFacts.nodes.filter((node) => isScopedSymbol(node, scopedPaths));
       const unsupportedFileExports = fileNodes.flatMap(unsupportedFileExportMetadata);
-      if (!scopedSymbols.some(hasExportMetadata) && unsupportedFileExports.length === 0) {
+      const filePathsWithUnsupportedExportMetadata = new Set(
+        fileNodes
+          .filter((node) => unsupportedFileExportMetadata(node).length > 0)
+          .map(fileNodePath)
+          .filter(isDefined)
+      );
+      const handshakeEdgeKinds = context.graphStatus.state === "available" ? context.graphStatus.handshake?.edgeKinds : undefined;
+      const fileReachabilitySupported = supportsAllEdgeKinds(handshakeEdgeKinds, fileReachabilityEdgeKinds);
+      const callUsageSupported = supportsAllEdgeKinds(handshakeEdgeKinds, callEdgeKinds);
+      const typeReferenceSupported = supportsAnyEdgeKind(handshakeEdgeKinds, typeReferenceEdgeKinds);
+      const unusedFiles = fileReachabilitySupported
+        ? unusedSourceFiles(fileNodes, scopedPaths, contains, importsFrom, filePathsWithUnsupportedExportMetadata)
+        : [];
+      if (!scopedSymbols.some(hasExportMetadata) && unsupportedFileExports.length === 0 && unusedFiles.length === 0) {
         return {
           diagnostics: [
             {
@@ -39,12 +61,11 @@ export function createDeadCodeCheck(): ValidationCheckDefinition {
 
       const exportedSymbols = scopedSymbols.filter(isExportedSymbol);
       const callCoveredExports = exportedSymbols.filter(hasCallUsageCoverage);
-      const unsupportedExports = exportedSymbols.filter((node) => !hasCallUsageCoverage(node));
+      const typeCoveredExports = exportedSymbols.filter(hasTypeUsageCoverage);
+      const unsupportedExports = exportedSymbols.filter((node) => !hasCallUsageCoverage(node) && !hasTypeUsageCoverage(node));
       if (
         callCoveredExports.length > 0 &&
-        context.graphStatus.state === "available" &&
-        context.graphStatus.handshake !== undefined &&
-        !context.graphStatus.handshake.edgeKinds.includes("CALLS")
+        !callUsageSupported
       ) {
         return {
           diagnostics: [
@@ -59,6 +80,7 @@ export function createDeadCodeCheck(): ValidationCheckDefinition {
       }
 
       const incomingCalls = new Set(calls.map((edge) => edge.to));
+      const incomingTypeReferences = new Set(typeReferences.map((edge) => edge.to));
       const diagnostics: ValidationDiagnostic[] = [];
       if (unsupportedFileExports.length > 0) {
         diagnostics.push(unsupportedFileExportMetadataDiagnostic(unsupportedFileExports));
@@ -66,8 +88,24 @@ export function createDeadCodeCheck(): ValidationCheckDefinition {
       if (unsupportedExports.length > 0) {
         diagnostics.push(unsupportedExportUsageDiagnostic(unsupportedExports));
       }
+      if (!fileReachabilitySupported && fileNodes.length > 0) {
+        diagnostics.push(unsupportedFileReachabilityDiagnostic());
+      }
+      const typeExportsBySupport = partitionTypeExportsByReferenceSupport(
+        typeCoveredExports,
+        typeReferences,
+        incomingTypeReferences,
+        importsFrom,
+        fileReachabilitySupported,
+        typeReferenceSupported
+      );
+      if (typeExportsBySupport.unsupported.length > 0) {
+        diagnostics.push(unsupportedTypeReferenceDiagnostic(typeExportsBySupport.unsupported));
+      }
+      diagnostics.push(...unusedFiles.map(unusedFileDiagnostic));
       diagnostics.push(
         ...callCoveredExports
+          .filter(() => callUsageSupported)
           .filter((node) => !hasIncomingCall(node, calls, incomingCalls))
           .map((node): ValidationDiagnostic => ({
             category: "graph",
@@ -77,6 +115,7 @@ export function createDeadCodeCheck(): ValidationCheckDefinition {
             message: `Exported symbol has no incoming CALLS graph evidence: ${node.name ?? node.id}`
           }))
       );
+      diagnostics.push(...typeExportsBySupport.unused.map(unusedTypeExportDiagnostic));
       return { diagnostics };
     }
   };
@@ -97,6 +136,10 @@ function hasCallUsageCoverage(node: GraphFactNode): boolean {
   return node.kind === "Function" || node.kind === "Class";
 }
 
+function hasTypeUsageCoverage(node: GraphFactNode): boolean {
+  return node.kind === "Type" || node.kind === "TypeAlias" || node.kind === "Interface";
+}
+
 function unsupportedExportUsageDiagnostic(nodes: readonly GraphFactNode[]): ValidationDiagnostic {
   const kinds = [...new Set(nodes.map((node) => node.kind))].sort().join(", ");
   return {
@@ -104,6 +147,24 @@ function unsupportedExportUsageDiagnostic(nodes: readonly GraphFactNode[]): Vali
     severity: "info",
     code: "TS_DEAD_CODE_UNSUPPORTED",
     message: `Graph facts include exported ${kinds} symbols, but TypeScript dead-code validation only has CALLS usage coverage for Function/Class exports.`
+  };
+}
+
+function unsupportedFileReachabilityDiagnostic(): ValidationDiagnostic {
+  return {
+    category: "graph",
+    severity: "info",
+    code: "TS_DEAD_CODE_UNSUPPORTED",
+    message: "Graph provider capability handshake does not include CONTAINS and IMPORTS_FROM coverage required for TypeScript unused-file validation."
+  };
+}
+
+function unsupportedTypeReferenceDiagnostic(nodes: readonly GraphFactNode[]): ValidationDiagnostic {
+  return {
+    category: "graph",
+    severity: "info",
+    code: "TS_DEAD_CODE_UNSUPPORTED",
+    message: `Graph facts include exported Type symbols in referenced files without symbol-level type reference evidence: ${symbolLabels(nodes)}.`
   };
 }
 
@@ -122,6 +183,76 @@ function unsupportedFileExportMetadataDiagnostic(exports: readonly FileExportMet
 
 function hasExportMetadata(node: GraphFactNode): boolean {
   return typeof node.attributes?.exported === "boolean";
+}
+
+function unusedSourceFiles(
+  fileNodes: readonly GraphFactNode[],
+  scopedPaths: ReadonlySet<string>,
+  contains: readonly GraphFactEdge[],
+  importsFrom: readonly GraphFactEdge[],
+  filePathsWithUnsupportedExportMetadata: ReadonlySet<string>
+): readonly GraphFactNode[] {
+  return fileNodes
+    .filter((node) => {
+      const path = fileNodePath(node);
+      if (path === undefined || !scopedPaths.has(path)) return false;
+      if (filePathsWithUnsupportedExportMetadata.has(path)) return false;
+      if (!hasFileContainsEdge(path, node, contains)) return false;
+      if (hasIncomingFileImport(path, node, importsFrom)) return false;
+      return true;
+    })
+    .sort((left, right) => (fileNodePath(left) ?? left.id).localeCompare(fileNodePath(right) ?? right.id));
+}
+
+function unusedFileDiagnostic(node: GraphFactNode): ValidationDiagnostic {
+  const path = fileNodePath(node) ?? node.path ?? node.id;
+  return {
+    category: "graph",
+    severity: "warning",
+    path,
+    code: "TS_DEAD_CODE_UNUSED_FILE",
+    message: `Source file has no incoming IMPORTS_FROM graph evidence: ${path}`
+  };
+}
+
+interface PartitionedTypeExports {
+  unused: readonly GraphFactNode[];
+  unsupported: readonly GraphFactNode[];
+}
+
+function partitionTypeExportsByReferenceSupport(
+  nodes: readonly GraphFactNode[],
+  typeReferences: readonly GraphFactEdge[],
+  incomingTypeReferences: ReadonlySet<string>,
+  importsFrom: readonly GraphFactEdge[],
+  fileReachabilitySupported: boolean,
+  typeReferenceSupported: boolean
+): PartitionedTypeExports {
+  const unused: GraphFactNode[] = [];
+  const unsupported: GraphFactNode[] = [];
+  for (const node of nodes) {
+    if (hasIncomingTypeReference(node, typeReferences, incomingTypeReferences)) continue;
+    const path = symbolFilePath(node);
+    if (path !== undefined && fileReachabilitySupported && !hasIncomingFileImport(path, undefined, importsFrom)) {
+      unused.push(node);
+      continue;
+    }
+    if (!typeReferenceSupported || path !== undefined) unsupported.push(node);
+  }
+  return {
+    unused: unused.sort(compareSymbols),
+    unsupported: unsupported.sort(compareSymbols)
+  };
+}
+
+function unusedTypeExportDiagnostic(node: GraphFactNode): ValidationDiagnostic {
+  return {
+    category: "graph",
+    severity: "warning",
+    path: symbolFilePath(node),
+    code: "TS_DEAD_CODE_UNUSED_EXPORT",
+    message: `Exported type has no incoming graph reference evidence: ${node.name ?? node.id}`
+  };
 }
 
 type FileExportMetadata = { [key: string]: JsonValue };
@@ -151,11 +282,45 @@ function isScopedSymbol(node: GraphFactNode, scopedPaths: ReadonlySet<string>): 
   return filePath !== undefined && scopedPaths.has(filePath);
 }
 
+function fileNodePath(node: GraphFactNode): string | undefined {
+  return node.path ?? stringAttribute(node, ["path", "file", "filePath", "sourcePath"]);
+}
+
+function hasFileContainsEdge(path: string, node: GraphFactNode, contains: readonly GraphFactEdge[]): boolean {
+  const aliases = fileAliases(path, node);
+  return contains.some((edge) => aliases.has(edge.from));
+}
+
+function hasIncomingFileImport(path: string, node: GraphFactNode | undefined, importsFrom: readonly GraphFactEdge[]): boolean {
+  const aliases = fileAliases(path, node);
+  return importsFrom.some((edge) => aliases.has(edge.to));
+}
+
+function fileAliases(path: string, node: GraphFactNode | undefined): ReadonlySet<string> {
+  const aliases = new Set([path, `file:${path}`]);
+  if (node !== undefined) aliases.add(node.id);
+  return aliases;
+}
+
 function symbolAliases(node: GraphFactNode): ReadonlySet<string> {
   const aliases = new Set([node.id]);
   const stableId = stringAttribute(node, ["symbolId", "stableId", "qualifiedName"]);
   if (stableId !== undefined) aliases.add(stableId);
   return aliases;
+}
+
+function hasIncomingTypeReference(
+  node: GraphFactNode,
+  typeReferences: readonly GraphFactEdge[],
+  incomingTypeReferences: ReadonlySet<string>
+): boolean {
+  if (incomingTypeReferences.has(node.id)) return true;
+  const aliases = symbolAliases(node);
+  return typeReferences.some((edge) => aliases.has(edge.to));
+}
+
+function isTypeReferenceEdge(edge: GraphFactEdge): boolean {
+  return (typeReferenceEdgeKinds as readonly string[]).includes(edge.kind);
 }
 
 function symbolFilePath(node: GraphFactNode): string | undefined {
@@ -164,6 +329,27 @@ function symbolFilePath(node: GraphFactNode): string | undefined {
   if (path !== undefined) return path;
   const match = /^[^:]+:([^#]+)(?:#.*)?$/.exec(node.id);
   return match?.[1];
+}
+
+function supportsAllEdgeKinds(handshakeEdgeKinds: readonly string[] | undefined, edgeKinds: readonly GraphEdgeKind[]): boolean {
+  if (handshakeEdgeKinds === undefined) return true;
+  return edgeKinds.every((edgeKind) => handshakeEdgeKinds.includes(edgeKind));
+}
+
+function supportsAnyEdgeKind(handshakeEdgeKinds: readonly string[] | undefined, edgeKinds: readonly GraphEdgeKind[]): boolean {
+  if (handshakeEdgeKinds === undefined) return true;
+  return edgeKinds.some((edgeKind) => handshakeEdgeKinds.includes(edgeKind));
+}
+
+function symbolLabels(nodes: readonly GraphFactNode[]): string {
+  return nodes
+    .map((node) => node.name ?? node.id)
+    .slice(0, 5)
+    .join(", ");
+}
+
+function compareSymbols(left: GraphFactNode, right: GraphFactNode): number {
+  return `${symbolFilePath(left) ?? ""}\0${left.name ?? left.id}`.localeCompare(`${symbolFilePath(right) ?? ""}\0${right.name ?? right.id}`);
 }
 
 function booleanAttribute(node: GraphFactNode, keys: readonly string[]): boolean {
@@ -184,4 +370,8 @@ function stringAttribute(node: GraphFactNode, keys: readonly string[]): string |
 
 function isStringValue(value: JsonValue | undefined): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
 }

--- a/packages/validation-typescript/src/graph-requirements.ts
+++ b/packages/validation-typescript/src/graph-requirements.ts
@@ -2,6 +2,8 @@ import type { ValidationCheckContext, ValidationGraphQueryRequirement } from "@t
 import type { GraphEdgeKind } from "@the-open-engine/opcore-contracts";
 import { materializeTypeScriptSources, toFileNodeId } from "./source-files.js";
 
+const deadCodeEdgeKinds = ["CALLS", "CONTAINS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS"] as const satisfies readonly GraphEdgeKind[];
+
 export async function importGraphRequirements(
   context: ValidationCheckContext
 ): Promise<readonly ValidationGraphQueryRequirement[]> {
@@ -17,7 +19,7 @@ export async function deadCodeGraphRequirements(
       operation: "factQuery",
       selector: {
         kind: "edges",
-        edgeKinds: ["CALLS"]
+        edgeKinds: deadCodeEdgeKinds
       }
     },
     {

--- a/tests/validation-typescript.test.mjs
+++ b/tests/validation-typescript.test.mjs
@@ -885,6 +885,230 @@ describe("validation-typescript adapter", () => {
     assert.deepEqual(result.diagnostics.map((diagnostic) => diagnostic.code), ["TS_DEAD_CODE_UNUSED_EXPORT"]);
   });
 
+  it("reports unreferenced source files and unused exported types from graph facts", async () => {
+    const nodes = [
+      {
+        id: "file:src/index.ts",
+        kind: "File",
+        path: "src/index.ts",
+        attributes: {
+          language: "typescript"
+        }
+      },
+      {
+        id: "file:src/used.ts",
+        kind: "File",
+        path: "src/used.ts",
+        attributes: {
+          language: "typescript"
+        }
+      },
+      {
+        id: "file:src/orphan.ts",
+        kind: "File",
+        path: "src/orphan.ts",
+        attributes: {
+          language: "typescript"
+        }
+      },
+      {
+        id: "type:src/orphan.ts#ReferencedShape",
+        kind: "Type",
+        path: "src/orphan.ts",
+        name: "ReferencedShape",
+        attributes: {
+          exported: true,
+          exportKind: "named",
+          exportName: "ReferencedShape"
+        }
+      },
+      {
+        id: "type:src/orphan.ts#LocalExtension",
+        kind: "Type",
+        path: "src/orphan.ts",
+        name: "LocalExtension",
+        attributes: {
+          exported: false
+        }
+      },
+      {
+        id: "type:src/orphan.ts#UnusedShape",
+        kind: "Type",
+        path: "src/orphan.ts",
+        name: "UnusedShape",
+        attributes: {
+          exported: true,
+          exportKind: "named",
+          exportName: "UnusedShape"
+        }
+      },
+      {
+        id: "variable:src/used.ts#used",
+        kind: "Variable",
+        path: "src/used.ts",
+        name: "used",
+        attributes: {
+          exported: false
+        }
+      }
+    ];
+    const edges = [
+      {
+        kind: "IMPORTS_FROM",
+        from: "file:src/index.ts",
+        to: "file:src/used.ts"
+      },
+      {
+        kind: "CONTAINS",
+        from: "file:src/used.ts",
+        to: "variable:src/used.ts#used"
+      },
+      {
+        kind: "CONTAINS",
+        from: "file:src/orphan.ts",
+        to: "type:src/orphan.ts#ReferencedShape"
+      },
+      {
+        kind: "CONTAINS",
+        from: "file:src/orphan.ts",
+        to: "type:src/orphan.ts#LocalExtension"
+      },
+      {
+        kind: "CONTAINS",
+        from: "file:src/orphan.ts",
+        to: "type:src/orphan.ts#UnusedShape"
+      },
+      {
+        kind: "INHERITS",
+        from: "type:src/orphan.ts#LocalExtension",
+        to: "type:src/orphan.ts#ReferencedShape"
+      }
+    ];
+
+    const result = await runner({
+      files: {
+        "src/index.ts": "import './used';\n",
+        "src/used.ts": "const used = 1;\nvoid used;\n",
+        "src/orphan.ts":
+          "export interface ReferencedShape { width: number; }\ninterface LocalExtension extends ReferencedShape { height: number; }\nexport interface UnusedShape { depth: number; }\n"
+      },
+      graphProviderClient: graphClient({
+        status: (validationRequest) => ({
+          ...availableStatus(validationRequest.graph.mode, validationRequest.repo),
+          handshake: graphHandshake()
+        }),
+        factQuery: (query) =>
+          availableFactResult(query, nodes, edges, {
+            edgeKinds: ["CALLS", "CONTAINS", "IMPORTS_FROM", "INHERITS", "IMPLEMENTS", "TESTED_BY"]
+          })
+      })
+    }).runValidation(
+      request({
+        checks: [TYPE_SCRIPT_DEAD_CODE_CHECK_ID],
+        scope: {
+          kind: "files",
+          files: ["src/index.ts", "src/used.ts", "src/orphan.ts"]
+        }
+      })
+    );
+
+    assert.equal(result.status, "passed");
+    assert.deepEqual(
+      result.diagnostics.map((diagnostic) => [diagnostic.code, diagnostic.path, diagnostic.message]),
+      [
+        ["TS_DEAD_CODE_UNUSED_EXPORT", "src/orphan.ts", "Exported type has no incoming graph reference evidence: UnusedShape"],
+        ["TS_DEAD_CODE_UNUSED_FILE", "src/orphan.ts", "Source file has no incoming IMPORTS_FROM graph evidence: src/orphan.ts"]
+      ]
+    );
+  });
+
+  it("reports unreferenced source files that import dependencies", async () => {
+    const nodes = [
+      {
+        id: "file:src/dead-entry.ts",
+        kind: "File",
+        path: "src/dead-entry.ts",
+        attributes: {
+          language: "typescript"
+        }
+      },
+      {
+        id: "file:src/helper.ts",
+        kind: "File",
+        path: "src/helper.ts",
+        attributes: {
+          language: "typescript"
+        }
+      },
+      {
+        id: "function:src/dead-entry.ts#runDead",
+        kind: "Function",
+        path: "src/dead-entry.ts",
+        name: "runDead",
+        attributes: {
+          exported: false
+        }
+      },
+      {
+        id: "function:src/helper.ts#helper",
+        kind: "Function",
+        path: "src/helper.ts",
+        name: "helper",
+        attributes: {
+          exported: false
+        }
+      }
+    ];
+    const edges = [
+      {
+        kind: "CONTAINS",
+        from: "file:src/dead-entry.ts",
+        to: "function:src/dead-entry.ts#runDead"
+      },
+      {
+        kind: "CONTAINS",
+        from: "file:src/helper.ts",
+        to: "function:src/helper.ts#helper"
+      },
+      {
+        kind: "IMPORTS_FROM",
+        from: "file:src/dead-entry.ts",
+        to: "file:src/helper.ts"
+      }
+    ];
+
+    const result = await runner({
+      files: {
+        "src/dead-entry.ts": "import { helper } from './helper';\nfunction runDead() { return helper(); }\nvoid runDead;\n",
+        "src/helper.ts": "export function helper() { return 1; }\n"
+      },
+      graphProviderClient: graphClient({
+        status: (validationRequest) => ({
+          ...availableStatus(validationRequest.graph.mode, validationRequest.repo),
+          handshake: graphHandshake()
+        }),
+        factQuery: (query) =>
+          availableFactResult(query, nodes, edges, {
+            edgeKinds: ["CALLS", "CONTAINS", "IMPORTS_FROM", "TESTED_BY"]
+          })
+      })
+    }).runValidation(
+      request({
+        checks: [TYPE_SCRIPT_DEAD_CODE_CHECK_ID],
+        scope: {
+          kind: "files",
+          files: ["src/dead-entry.ts", "src/helper.ts"]
+        }
+      })
+    );
+
+    assert.equal(result.status, "passed");
+    assert.deepEqual(
+      result.diagnostics.map((diagnostic) => [diagnostic.code, diagnostic.path, diagnostic.message]),
+      [["TS_DEAD_CODE_UNUSED_FILE", "src/dead-entry.ts", "Source file has no incoming IMPORTS_FROM graph evidence: src/dead-entry.ts"]]
+    );
+  });
+
   it("reports unsupported coverage, not unused exports, for real graph-provider type-only exports", () => {
     const repo = mkdtempSync(join(tmpdir(), "lattice-dead-code-real-provider-"));
     try {
@@ -943,8 +1167,13 @@ describe("validation-typescript adapter", () => {
       );
       assert.equal(check.status, 0, check.stderr || check.stdout);
       const payload = JSON.parse(check.stdout);
-      const diagnosticCodes = payload.validationResult.diagnostics.map((diagnostic) => diagnostic.code);
-      assert.deepEqual(diagnosticCodes, ["TS_DEAD_CODE_UNSUPPORTED"]);
+      assert.deepEqual(
+        payload.validationResult.diagnostics.map((diagnostic) => [diagnostic.code, diagnostic.path]),
+        [
+          ["TS_DEAD_CODE_UNSUPPORTED", undefined],
+          ["TS_DEAD_CODE_UNUSED_FILE", "src/index.ts"]
+        ]
+      );
       assert.equal(
         payload.validationResult.diagnostics.some(
           (diagnostic) => diagnostic.code === "TS_DEAD_CODE_UNUSED_EXPORT" && /Shape|Payload/.test(diagnostic.message)
@@ -1383,7 +1612,11 @@ describe("validation-typescript adapter", () => {
       const payload = JSON.parse(check.stdout);
       assert.deepEqual(
         payload.validationResult.diagnostics.map((diagnostic) => diagnostic.code),
-        []
+        ["TS_DEAD_CODE_UNUSED_FILE"]
+      );
+      assert.equal(
+        payload.validationResult.diagnostics.some((diagnostic) => diagnostic.code === "TS_DEAD_CODE_UNUSED_EXPORT"),
+        false
       );
     } finally {
       rmSync(repo, { recursive: true, force: true });


### PR DESCRIPTION
Problem
`typescript.dead-code` only used `CALLS` evidence for exported Function/Class symbols. Type exports and isolated source files stayed unsupported even when graph facts had enough reachability evidence to report them.

Approach
- Preload `CALLS`, `CONTAINS`, `IMPORTS_FROM`, `INHERITS`, and `IMPLEMENTS` for the dead-code check.
- Report isolated scoped TypeScript source files with graph `CONTAINS` evidence and no `IMPORTS_FROM` reachability as `TS_DEAD_CODE_UNUSED_FILE`.
- Report exported `Type`/`TypeAlias`/`Interface` symbols as unused when graph reachability/reference facts support that conclusion; keep ambiguous imported type-only coverage as informational `TS_DEAD_CODE_UNSUPPORTED`.
- Keep graph-unavailable behavior on the existing optional/required validation policy path.

Rox comparison
Current local Rox comparison used `.ace/runtime/bin/rox check --all --checks deadCode --json --no-daemon` on a temp TS fixture with an unused file/type. The wrapper manifest still reported `deadCode` disabled under the temp config, and the check returned `[]`. This PR does not claim Rox parity; Opcore remains narrower where graph facts only provide file-level type imports rather than symbol-level type references.

Verification
- `npm run build`
- `node --test tests/validation-typescript.test.mjs`
- `npm run lint`
- `npm_config_cache=/private/tmp/opcore-npm-cache npm run pack:check`
- `npm run current-tools:validate-changed`

Fixes #147