### PR TITLE
fix(ci): restore main validation gates

### DIFF
--- a/crates/graph-core/src/clone/persistence.rs
+++ b/crates/graph-core/src/clone/persistence.rs
@@ -84,10 +84,12 @@ fn status_has_clone_source_change(output: &[u8]) -> bool {
 }
 
 fn parse_status_entry(entry: &[u8]) -> Option<([u8; 2], &[u8])> {
-    if entry.len() < 4 || entry[2] != b' ' {
-        return None;
+    match entry {
+        [index_status, worktree_status, b' ', path @ ..] if !path.is_empty() => {
+            Some(([*index_status, *worktree_status], path))
+        }
+        _ => None,
     }
-    Some(([entry[0], entry[1]], &entry[3..]))
 }
 
 fn status_mentions_rename_or_copy(status: [u8; 2]) -> bool {

--- a/packages/opcore-graph-core-darwin-arm64/metadata.json
+++ b/packages/opcore-graph-core-darwin-arm64/metadata.json
@@ -4,6 +4,6 @@
   "targetPlatform": "darwin-arm64",
   "binaryPath": "opcore-graph-core",
   "checksumPath": "opcore-graph-core.sha256",
-  "checksumSha256": "01e834a5d0104ca9626b6ac78da1977bea87a62608abfdfba4bd3ea0ccea7508",
+  "checksumSha256": "d9f3e73c599a26b756cdd5a582225277af1562845172801b52ad9ac6851bf602",
   "buildProfile": "release"
 }

--- a/packages/opcore-graph-core-darwin-arm64/opcore-graph-core.sha256
+++ b/packages/opcore-graph-core-darwin-arm64/opcore-graph-core.sha256
@@ -1,1 +1,1 @@
-01e834a5d0104ca9626b6ac78da1977bea87a62608abfdfba4bd3ea0ccea7508  opcore-graph-core
+d9f3e73c599a26b756cdd5a582225277af1562845172801b52ad9ac6851bf602  opcore-graph-core

--- a/tests/asp-provider.test.mjs
+++ b/tests/asp-provider.test.mjs
@@ -13,6 +13,7 @@ const forbiddenKeys = new Set(["decision", "verdict", "pass", "authority", "assu
 const allCheckIds = [
   "typescript.syntax",
   "typescript.types",
+  "typescript.lint",
   "typescript.import-graph",
   "typescript.dead-code",
   "typescript.function-metrics",
@@ -34,7 +35,16 @@ const allCheckIds = [
   "python.types",
   "python.import-graph",
   "python.dead-code",
-  "python.relevant-tests"
+  "python.relevant-tests",
+  "docs.existence",
+  "docs.staleness",
+  "docs.freshness",
+  "docs.length",
+  "docs.dry",
+  "docs.content-quality",
+  "docs.code-blocks",
+  "docs.rules-why",
+  "docs.hub-coverage"
 ];
 
 describe("Opcore ASP provider", () => {

--- a/tests/installed-bins.test.mjs
+++ b/tests/installed-bins.test.mjs
@@ -27,6 +27,7 @@ const packageNames = [
   "@the-open-engine/opcore-edit",
   "@the-open-engine/opcore-validation",
   "@the-open-engine/opcore-validation-clone",
+  "@the-open-engine/opcore-validation-docs",
   "@the-open-engine/opcore-validation-python",
   "@the-open-engine/opcore-validation-rust",
   "@the-open-engine/opcore-validation-typescript",
@@ -113,6 +114,7 @@ describe("installed package bins", () => {
         [
           "typescript.syntax",
           "typescript.types",
+          "typescript.lint",
           "typescript.import-graph",
           "typescript.dead-code",
           "typescript.function-metrics",
@@ -134,7 +136,17 @@ describe("installed package bins", () => {
           "python.types",
           "python.import-graph",
           "python.dead-code",
-          "python.relevant-tests"
+          "python.relevant-tests",
+          "docs.existence",
+          "docs.staleness",
+          "docs.freshness",
+          "docs.length",
+          "docs.dry",
+          "docs.content-quality",
+          "docs.code-blocks",
+          "docs.rules-why",
+          "docs.hub-coverage",
+          "clone.duplication"
         ]
       );
       assert.equal(assertSmoke(project, ["validate", "manifest", "--json"], 0).validationResult.status, "passed");
@@ -213,9 +225,11 @@ describe("installed package bins", () => {
         "@the-open-engine/opcore-edit",
         "@the-open-engine/opcore-validation",
         "@the-open-engine/opcore-validation-clone",
+        "@the-open-engine/opcore-validation-docs",
         "@the-open-engine/opcore-validation-python",
         "@the-open-engine/opcore-validation-rust",
         "@the-open-engine/opcore-validation-typescript",
+        "@the-open-engine/opcore-asp-provider",
         "@the-open-engine/opcore"
       ].map((packageName) => packWorkspace(packageName, temp));
       const project = join(temp, "project");
@@ -248,9 +262,11 @@ describe("installed package bins", () => {
         "@the-open-engine/opcore-edit",
         "@the-open-engine/opcore-validation",
         "@the-open-engine/opcore-validation-clone",
+        "@the-open-engine/opcore-validation-docs",
         "@the-open-engine/opcore-validation-python",
         "@the-open-engine/opcore-validation-rust",
         "@the-open-engine/opcore-validation-typescript",
+        "@the-open-engine/opcore-asp-provider",
         "@the-open-engine/opcore"
       ].map((packageName) => packWorkspace(packageName, temp));
       const project = join(temp, "project");

--- a/tests/validation-cli.test.mjs
+++ b/tests/validation-cli.test.mjs
@@ -55,7 +55,8 @@ const docsCheckIds = [
   "docs.hub-coverage"
 ];
 const cloneCheckIds = ["clone.duplication"];
-const executableDefaultCheckIds = [...typeScriptCheckIds, ...rustCheckIds, ...pythonCheckIds];
+const typeScriptExecutableDefaultCheckIds = typeScriptCheckIds.filter((checkId) => checkId !== "typescript.lint");
+const executableDefaultCheckIds = [...typeScriptExecutableDefaultCheckIds, ...rustCheckIds, ...pythonCheckIds, ...cloneCheckIds];
 const defaultCheckIds = [...typeScriptCheckIds, ...rustCheckIds, ...pythonCheckIds, ...docsCheckIds, ...cloneCheckIds];
 
 describe("validation CLI", () => {
@@ -91,7 +92,7 @@ describe("validation CLI", () => {
       const result = run(args, [0, 1]);
       assert.equal(result.owner, "validation");
       assert.equal(result.exitCode === 0 || result.exitCode === 1, true);
-      assert.equal(result.validationResult.manifest.checks.length, executableDefaultCheckIds.length);
+      assert.deepEqual(result.validationResult.manifest.checks, executableDefaultCheckIds);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "entries"), false);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "runs"), false);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "skippedChecks"), false);

--- a/tests/validation-cli.test.mjs
+++ b/tests/validation-cli.test.mjs
@@ -15,6 +15,7 @@ const latticeBin = fileURLToPath(new URL("../packages/opcore/dist/advanced/index
 const typeScriptCheckIds = [
   "typescript.syntax",
   "typescript.types",
+  "typescript.lint",
   "typescript.import-graph",
   "typescript.dead-code",
   "typescript.function-metrics",
@@ -42,8 +43,20 @@ const pythonCheckIds = [
   "python.dead-code",
   "python.relevant-tests"
 ];
+const docsCheckIds = [
+  "docs.existence",
+  "docs.staleness",
+  "docs.freshness",
+  "docs.length",
+  "docs.dry",
+  "docs.content-quality",
+  "docs.code-blocks",
+  "docs.rules-why",
+  "docs.hub-coverage"
+];
 const cloneCheckIds = ["clone.duplication"];
-const defaultCheckIds = [...typeScriptCheckIds, ...rustCheckIds, ...pythonCheckIds, ...cloneCheckIds];
+const executableDefaultCheckIds = [...typeScriptCheckIds, ...rustCheckIds, ...pythonCheckIds];
+const defaultCheckIds = [...typeScriptCheckIds, ...rustCheckIds, ...pythonCheckIds, ...docsCheckIds, ...cloneCheckIds];
 
 describe("validation CLI", () => {
   it("keeps opcore status separate from validation execution results", async () => {
@@ -78,7 +91,7 @@ describe("validation CLI", () => {
       const result = run(args, [0, 1]);
       assert.equal(result.owner, "validation");
       assert.equal(result.exitCode === 0 || result.exitCode === 1, true);
-      assert.equal(result.validationResult.manifest.checks.length, defaultCheckIds.length);
+      assert.equal(result.validationResult.manifest.checks.length, executableDefaultCheckIds.length);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "entries"), false);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "runs"), false);
       assert.equal(Object.hasOwn(result.validationResult.manifest, "skippedChecks"), false);
@@ -211,6 +224,7 @@ describe("validation CLI", () => {
       assert.equal(result.validationResult.manifest.checks.includes("rust.file-length"), true);
       assert.equal(result.validationResult.manifest.checks.includes("python.syntax"), true);
       assert.equal(result.validationResult.manifest.checks.includes("python.import-graph"), true);
+      assert.equal(result.validationResult.manifest.checks.includes("docs.existence"), true);
     }
   });
 


### PR DESCRIPTION
**Problem**
`origin/main` was red after the validation-docs merge. Rust clippy rejected unchecked status-entry indexing in `graph-core`, and validation/installed-package tests still asserted the pre-docs/pre-clone manifest surface.

**Approach**
- Parse clone status entries with slice pattern matching instead of direct indexing.
- Update ASP, validation CLI, and installed-bin manifest expectations for `typescript.lint`, docs checks, and clone validation.
- Refresh the tracked darwin-arm64 graph-core native artifact for the changed Rust binary.

**Verification**
- `cargo fmt --check`
- `cargo clippy -p opcore-graph-core --all-targets --locked -- -D warnings`
- `cargo test -p opcore-graph-core clone --locked`
- `npm run setup:tools && npm run current-tools:validate-changed`
- `node --test tests/asp-provider.test.mjs tests/validation-cli.test.mjs`
- `node --test tests/installed-bins.test.mjs`
- `npm run ci`