### PR TITLE
fix(opcore): document the separate ASP provider package in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Opcore is **Layer 02 · Constraints** of [The Open Engine](https://theopenengine
 
 Each layer ships the same way: extracted from the platform we run, then opened.
 
+## ASP provider
+
+Opcore's ASP Core check provider ships as a separate package, `@the-open-engine/opcore-asp-provider`, and launches as `opcore-asp-provider --stdio`. Providers assess; hosts decide.
+
 ## Docs
 
 **[Quickstart](docs/quickstart.md) · [Concepts: coverage & findings](docs/concepts.md) · [Agent integration](docs/agent-integration.md) · [Architecture](docs/architecture/runtime-cli-ard.md) · [The Open Engine](https://theopenengine.com)**


### PR DESCRIPTION
Fixes the sole remaining CI failure on `main` after #181: `package-identity.test.mjs` requires the root README to reference the standalone ASP Core check provider (`opcore-asp-provider --stdio` and `@the-open-engine/opcore-asp-provider`), which the #180 rewrite dropped.

Adds a short ASP provider section. Verified locally: `package-identity` passes, `check-workspace` and `release:hygiene` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)