### PR TITLE
docs(seo): add llms.txt for agent and answer-engine discovery

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,45 @@
+# Opcore
+
+> Opcore is a deterministic, local, read-only robustness loop and a changed-file JSON validation gate for AI coding agents. It prints coverage before findings, reads real code structure from a Rust graph core, and returns stable exit codes. Opcore is Layer 02 (Constraints) of The Open Engine, sibling to the verification layer Zeroshot.
+
+Opcore is maintainer-controlled alpha (0.1.0-alpha.0). Hybrid runtime: a Rust graph core owns source extraction, persistence, and hot graph queries; TypeScript owns contracts, CLI routing, and validation policy.
+
+## What Opcore is
+- Deterministic, local, read-only robustness loop for repositories worked on by coding agents.
+- A changed-file JSON validation gate: `opcore check --changed --json` with stable exit codes (0 pass, 1 findings or error, 64 unsupported), default base HEAD, works in a fresh `git init`.
+- Structural signals from a graph core: dead exports, untested surface, fan-in hotspots, Rust module cycles — as drillable facts, not LLM opinions.
+- Honest coverage tiers, stated before findings: deep TypeScript/JavaScript, useful Rust, experimental degraded-honest Python, unsupported stacks counted.
+
+## What Opcore is NOT
+- Not a security scanner and not SAST.
+- Does not auto-fix, rewrite, or edit your source.
+- Does not emit a blended quality score.
+- Does not detect AI authorship.
+- Does not claim coverage of every language or stack.
+- Not a cloud service; it runs locally.
+- Does not replace existing lint, test, CI, or pre-commit guardrails.
+
+## Core commands
+- `opcore` — read-only scan; prints Coverage before Findings; writes only `.opcore/report.json`, `.opcore/history.jsonl`, and bounded `.opcore/telemetry.jsonl`.
+- `opcore status [--json]` — read-only readiness and coverage; never writes.
+- `opcore init [--approve]` — scan-first, approval-gated, additive, reversible setup (one delimited block in AGENTS.md/CLAUDE.md, `.opcore/config`, managed `.gitignore` line, undo metadata).
+- `opcore check --changed --json` — the agent gate; stable exit codes; defaults `--base HEAD`.
+- `opcore check --staged --json` — pre-commit gate.
+- `opcore measure [--json]` — concrete before/after deltas from local history; no score.
+- `opcore try [--json]` — local sample-repo demo loop; publishes nothing.
+
+## Install
+- Maintainer-controlled alpha: package publication is gated during alpha staging. Until the packages are published, run Opcore from a source checkout: `npm ci && npm run build`, then `node packages/opcore/dist/index.js init --repo /path/to/repo`.
+- After package publication: `npx @the-open-engine/opcore@0.1.0-alpha.0 init` or `npm install -g @the-open-engine/opcore@0.1.0-alpha.0`.
+- Supported targets: darwin-arm64, darwin-x64, linux-x64. Windows is out of scope for 0.1.0-alpha.0.
+
+## Docs
+- README: https://github.com/the-open-engine/opcore#readme
+- Quickstart: https://github.com/the-open-engine/opcore/blob/main/docs/quickstart.md
+- Concepts: https://github.com/the-open-engine/opcore/blob/main/docs/concepts.md
+- Agent integration: https://github.com/the-open-engine/opcore/blob/main/docs/agent-integration.md
+
+## The Open Engine
+- Company: The Open Engine Company (legal: Covibes Inc.) — https://theopenengine.com
+- Layer 01 Verification — Zeroshot (open, shipping): https://github.com/the-open-engine/zeroshot
+- Layer 02 Constraints — Opcore (this repo)


### PR DESCRIPTION
## What

Adds a single root-level `llms.txt` so IDE coding agents and answer engines (ChatGPT/Claude/Perplexity) have a clean, extractable description of Opcore.

It carries:
- the one-line definition (deterministic, local, read-only robustness loop + changed-file JSON gate);
- **what Opcore is** and the explicit **What Opcore is NOT** list — the primary GEO citation surface (no security scanner/SAST, no auto-fix, no blended score, no AI-authorship, no all-stack, not cloud, does not replace existing lint/test/CI/pre-commit);
- core commands, install, docs links, and The Open Engine layer context (Layer 02 · Constraints, sibling to Zeroshot).

## Scope and intent

- **`llms.txt` only.** The README is intentionally left unchanged to preserve its strict, distributed token contract and its freshly redesigned hero. The niche keywords already live in the README lede.
- **No JSON-LD in the repo** — GitHub strips `<script>`, so structured data belongs on the landing page, not here.
- Content is adapted from the launch SEO/GEO package, edited only for accuracy: the install section and Zeroshot status mirror the README's maintainer-controlled-alpha honesty, and the changed-file gate exit codes match the `opcore check` documented `0` / `1` / `64` contract.

## Verification (all run against this branch's worktree)

| Gate | Result |
| --- | --- |
| `node scripts/check-workspace.mjs` | pass |
| `node scripts/check-release-hygiene.mjs` | pass (README tokens + claim scrub) |
| `node scripts/check-provenance.mjs` | pass (tracked files + full git history) |
| `node --test tests/package-identity.test.mjs tests/asp-provider.test.mjs` | pass (14/14) |
| `npm run pack:check` | pass (15 packages) |

The `@the-open-engine/opcore` pack is unchanged (99 files; `files: ["dist","README.md"]`) — the root `llms.txt` is not included in any package. The diff is a single new file (`llms.txt`, +45).

Ready for maintainer review; not for merge without approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
