### PR TITLE
Fix validation check namespaces and tsconfig references

### DIFF
--- a/packages/validation-typescript/src/compiler-options.ts
+++ b/packages/validation-typescript/src/compiler-options.ts
@@ -143,32 +143,40 @@ async function parseTypeScriptConfigs(
   paths: readonly string[]
 ): Promise<readonly ParsedTypeScriptConfig[]> {
   const configs: ParsedTypeScriptConfig[] = [];
-  for (const path of paths) {
+  const pending = [...paths];
+  const seen = new Set<string>();
+  while (pending.length > 0) {
+    const path = pending.shift();
+    if (path === undefined || seen.has(path)) continue;
+    seen.add(path);
     const content = await readOptionalRepoFile(context, path);
     if (content === undefined) continue;
     const diagnostics: ts.Diagnostic[] = [];
+    const basePath = configBasePath(path);
     const parsed = ts.parseConfigFileTextToJson(path, content);
     if (parsed.error !== undefined) {
       diagnostics.push(parsed.error);
       configs.push({
         path,
-        basePath: configBasePath(path),
+        basePath,
         options: mergeCompilerOptions(),
         diagnostics
       });
       continue;
     }
-    const converted = ts.convertCompilerOptionsFromJson(parsed.config?.compilerOptions ?? {}, configBasePath(path), path);
+    const converted = ts.convertCompilerOptionsFromJson(parsed.config?.compilerOptions ?? {}, basePath, path);
+    const references = referencedConfigPaths(basePath, parsed.config?.references);
     diagnostics.push(...converted.errors);
     configs.push({
       path,
-      basePath: configBasePath(path),
+      basePath,
       options: mergeCompilerOptions(converted.options),
       diagnostics,
       files: stringArray(parsed.config?.files),
       include: stringArray(parsed.config?.include),
       exclude: stringArray(parsed.config?.exclude)
     });
+    pending.push(...references);
   }
   return configs;
 }
@@ -297,6 +305,22 @@ function ancestorDirectories(path: string): readonly string[] {
 function isTypeScriptConfigPath(path: string): boolean {
   const name = path.split("/").at(-1) ?? "";
   return /^tsconfig(?:\.[^/]+)?\.json$/u.test(name);
+}
+
+function referencedConfigPaths(basePath: string, value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  const paths: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+    const referencePath = (entry as { path?: unknown }).path;
+    if (typeof referencePath !== "string" || referencePath.trim().length === 0) continue;
+    const normalizedReference = referencePath.trim().replaceAll("\\", "/");
+    const joined = joinRepoPaths(basePath, normalizedReference);
+    if (joined === undefined) continue;
+    const configPath = isTypeScriptConfigPath(joined) ? joined : joinRepoPaths(joined, "tsconfig.json");
+    if (configPath !== undefined) paths.push(configPath);
+  }
+  return uniqueSorted(paths);
 }
 
 function stringArray(value: unknown): readonly string[] | undefined {

--- a/packages/validation/src/command-options.ts
+++ b/packages/validation/src/command-options.ts
@@ -340,10 +340,10 @@ function parseCommonOptions(args: readonly string[]): {
       state.checks.push(inlineValue(arg, "--check"));
     } else if (arg === "--checks") {
       state.checkFilterFlag = true;
-      state.checks.push(...splitPaths(requiredValue(args, ++index, "--checks")));
+      state.checks.push(...splitCheckIds(requiredValue(args, ++index, "--checks")));
     } else if (arg.startsWith("--checks=")) {
       state.checkFilterFlag = true;
-      state.checks.push(...splitPaths(inlineValue(arg, "--checks")));
+      state.checks.push(...splitCheckIds(inlineValue(arg, "--checks")));
     }
     else if (arg === "--introduced") {
       state.reportModeFlag = true;
@@ -534,6 +534,13 @@ function reportModeValue(value: string): ValidationReportMode {
 function splitPaths(value: string): string[] {
   return value
     .split(/[,:]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function splitCheckIds(value: string): string[] {
+  return value
+    .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
 }

--- a/tests/validation-command-options.test.mjs
+++ b/tests/validation-command-options.test.mjs
@@ -95,6 +95,17 @@ describe("validation command timeout options", () => {
 });
 
 describe("check command options", () => {
+  it("preserves colon-delimited namespaced check ids in --checks", () => {
+    assert.deepEqual(parseCheckCommandOptions(["all", "--checks", "custom:security,custom:typescript"]).checks, [
+      "custom:security",
+      "custom:typescript"
+    ]);
+    assert.deepEqual(parseCheckCommandOptions(["all", "--checks=custom:agent-execution-boundaries"]).checks, [
+      "custom:agent-execution-boundaries"
+    ]);
+    assert.deepEqual(parseCheckCommandOptions(["all", "--check", "custom:security"]).checks, ["custom:security"]);
+  });
+
   it("parses fail-fast and streaming flags for execution routes", () => {
     assert.deepEqual(parseCheckCommandOptions(["files", "--files", "src/index.ts", "--fail-fast", "--stream"]), {
       route: "files",

--- a/tests/validation-typescript.test.mjs
+++ b/tests/validation-typescript.test.mjs
@@ -428,6 +428,38 @@ describe("validation-typescript adapter", () => {
     assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
   });
 
+  it("resolves solution-style tsconfig references for scoped path aliases", async () => {
+    const result = await runner({
+      files: {
+        "tsconfig.json": JSON.stringify({
+          files: [],
+          references: [{ path: "./tsconfig.app.json" }]
+        }),
+        "tsconfig.app.json": JSON.stringify({
+          compilerOptions: {
+            baseUrl: "./src",
+            paths: {
+              "@/*": ["*"]
+            }
+          },
+          include: ["src"]
+        }),
+        "src/a.ts": "export const a = 1;\n",
+        "src/b.ts": "import { a } from '@/a';\nexport const b: number = a;\n"
+      }
+    }).runValidation(
+      request({
+        checks: [TYPE_SCRIPT_TYPES_CHECK_ID],
+        scope: {
+          kind: "files",
+          files: ["src/b.ts"]
+        }
+      })
+    );
+
+    assert.equal(result.status, "passed", JSON.stringify(result.diagnostics, null, 2));
+  });
+
   it("uses nearest nested tsconfig options for full-repo TypeScript validation", async () => {
     const result = await runner({
       files: {


### PR DESCRIPTION
## Summary
- preserve colon-delimited validation check IDs passed via `--checks`, while keeping comma-separated lists supported
- recursively load TypeScript project references so solution-style root tsconfigs can contribute path alias compiler options
- add regression coverage for namespaced check IDs and referenced tsconfig path aliases

Fixes #190.
Fixes #191.

## Verification
- `npm run build`
- `node --test tests/validation-command-options.test.mjs tests/validation-typescript.test.mjs --test-reporter=spec`
- `npm run test:ci`
- `npm run lint`
- `git diff --check`