### PR TITLE
fix: skip pre-commit setup in linked worktrees

### DIFF
--- a/packages/opcore/src/init.ts
+++ b/packages/opcore/src/init.ts
@@ -871,7 +871,11 @@ function planInit(
 ): PlannedInit {
   if (options.scope === "global") return planGlobalInit(repoRoot, requestedPath, homeRoot, options, context);
   const agentFiles = detectAgentFiles(repoRoot);
-  const activePreCommitWritePlanned = options.activePreCommitHook && git && !repoPathExists(repoRoot, activePreCommitHookPath);
+  const linkedGitWorktree = git && isLinkedGitWorktree(repoRoot);
+  const activePreCommitWritePlanned = options.activePreCommitHook &&
+    git &&
+    !linkedGitWorktree &&
+    !repoPathExists(repoRoot, activePreCommitHookPath);
   const config = createConfig(repoRoot, options.failClosedHook, activePreCommitWritePlanned, context.scan, context.settings);
   const writes: PlannedWrite[] = [
     {
@@ -973,7 +977,8 @@ function planInit(
         options.failClosedHook,
         options.scope,
         activePreCommitWritePlanned,
-        options.activePreCommitHook && git
+        options.activePreCommitHook && git,
+        linkedGitWorktree
       ),
       nextActions: initNextActions(options),
       undoAvailable: repoPathExists(repoRoot, undoPath),
@@ -1036,7 +1041,7 @@ function planGlobalInit(
       },
       agentFiles: [],
       actions: createInitActions(options.scope, [], options, false, false),
-      warnings: initWarnings(context.scan, true, false, options.scope, false, false),
+      warnings: initWarnings(context.scan, true, false, options.scope, false, false, false),
       nextActions: initNextActions(options),
       undoAvailable: repoPathExists(homeRoot, globalUndoPath),
       scan: context.scan,
@@ -1415,7 +1420,8 @@ function initWarnings(
   failClosedHook: boolean,
   scope: ParsedInitArgs["scope"],
   activePreCommitHook: boolean,
-  activePreCommitRequested: boolean
+  activePreCommitRequested: boolean,
+  linkedGitWorktree: boolean
 ): string[] {
   const warnings: string[] = [];
   if (scan.unsupportedStacks.length > 0) {
@@ -1438,6 +1444,8 @@ function initWarnings(
       ? `Fail-closed hook script is opt-in. Manual install required: ${failClosedHookActivationCommand}`
       : activePreCommitHook && git
         ? "Git pre-commit hook will run opcore check --changed when no existing .git/hooks/pre-commit is present."
+        : linkedGitWorktree
+          ? "Linked Git worktree detected; Opcore will not install .git/hooks/pre-commit from this checkout."
         : activePreCommitRequested
           ? "Existing .git/hooks/pre-commit detected; Opcore will not overwrite it."
         : "Fail-closed hooks are opt-in and are not created unless --fail-closed-hook is approved."
@@ -1844,6 +1852,11 @@ function assertExistingAncestorInsideRepo(repoRoot: string, absolutePath: string
 
 function repoPathExists(repoRoot: string, path: string): boolean {
   return lstatIfExists(resolveRepoPath(repoRoot, path)) !== undefined;
+}
+
+function isLinkedGitWorktree(repoRoot: string): boolean {
+  const gitPath = lstatIfExists(resolveRepoPath(repoRoot, ".git"));
+  return gitPath?.isFile() === true;
 }
 
 function lstatIfExists(path: string): ReturnType<typeof lstatSync> | undefined {

--- a/tests/opcore-facade.test.mjs
+++ b/tests/opcore-facade.test.mjs
@@ -608,6 +608,34 @@ describe("opcore public facade", () => {
     }
   });
 
+  it("skips active pre-commit setup in linked Git worktrees without failing install", () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-install-linked-worktree-"));
+    const repo = join(temp, "repo");
+    const linked = join(temp, "linked");
+    try {
+      mkdirSync(repo);
+      initGitFixture(repo);
+      run("git", ["worktree", "add", "-b", "linked-install-test", linked, "main"], repo, 0);
+
+      const plan = parseJson(runOpcore(["install", "--repo", linked, "--json"], linked, 0).stdout);
+
+      assert.equal(plan.opcoreInit.actions.some((action) => action.path === ".git/hooks/pre-commit"), false);
+      assert.match(plan.message, /\[ \] Install Git pre-commit hook/);
+      assert.match(plan.message, /Linked Git worktree detected/);
+
+      const apply = parseJson(runOpcore(["install", "--repo", linked, "--yes", "--json"], linked, 0).stdout);
+      const config = JSON.parse(readFileSync(join(linked, ".opcore", "config"), "utf8"));
+      const undo = JSON.parse(readFileSync(join(linked, ".opcore", "init-undo.json"), "utf8"));
+
+      assert.equal(apply.opcoreInit.approved, true);
+      assert.equal(config.hooks.activePreCommit, false);
+      assert.equal(undo.entries.some((entry) => entry.path === ".git/hooks/pre-commit"), false);
+      assert.equal(existsSync(join(linked, ".opcore", "hooks", "opcore-agent-gate.mjs")), true);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   it("applies install with skills, write gates, active pre-commit, and uninstall", () => {
     const temp = mkdtempSync(join(tmpdir(), "opcore-install-apply-"));
     try {


### PR DESCRIPTION
## Summary
- detect linked Git worktrees where `.git` is a file and skip active `.git/hooks/pre-commit` setup instead of probing below `.git`
- keep the rest of `opcore install` working in linked worktrees and show a clear warning
- add a regression test using a real `git worktree add` fixture

## Manual install testing
- orchestra linked worktree: `opcore install --yes` succeeded, skipped pre-commit with linked-worktree warning, `opcore uninstall --yes` restored the worktree clean
- normal local clone with `.git/` directory: install created `.git/hooks/pre-commit`, uninstall removed it and restored the worktree clean
- normal repo with existing pre-commit hook: install skipped the hook, uninstall preserved it, worktree clean
- non-Git repo: install/undo succeeded and left only the original source file
- actual interactive linked-worktree TTY path: repo/global prompt -> repo -> plan -> default approval applied without `ENOTDIR`

## Validation
- red regression reproduced `ENOTDIR: not a directory, lstat .../.git/hooks/pre-commit` before the fix
- `npm run build`
- `node --test --test-name-pattern "linked Git worktrees" tests/opcore-facade.test.mjs`
- `node --test --test-name-pattern "install|init|uninstall" tests/opcore-facade.test.mjs tests/opcore-postinstall.test.mjs`
- `node --test tests/opcore-facade.test.mjs`
- `npm run lint`
- `npm run pack:check`
- `npm run release:hygiene`
- `npm run ci`
- `npm run setup:tools && npm run current-tools:validate-changed && npm run current-tools:validate-rust-graph`
- `npm run release-receipt:check`
- `OPCORE_CUTOVER_REUSE_CURRENT_TOOL_GUARDRAILS=1 npm run cutover:check`

## Follow-up
- Visual wizard redesign tracked separately in #199.
