### PR TITLE
Fix token-based npm release publish

### DIFF
--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -97,10 +97,14 @@ function verifyTokenMetadataWhenReadable() {
 }
 
 function publishArgs(packageName, options = {}) {
-  const args = ["publish", "--access", "public", "--tag", tag];
-  if (hasTrustedPublishingContext() && !options.dryRun) args.push("--provenance");
+  const args = ["publish", "--access", "public", "--tag", tag, "--loglevel", "notice"];
+  if (shouldPublishWithProvenance(options)) args.push("--provenance");
   if (options.dryRun) args.push("--dry-run");
   return args;
+}
+
+function shouldPublishWithProvenance(options = {}) {
+  return hasTrustedPublishingContext() && !hasTokenAuth() && !options.dryRun;
 }
 
 function withStagedPublishPackages(callback) {

--- a/tests/native-packaging-policy.test.mjs
+++ b/tests/native-packaging-policy.test.mjs
@@ -33,6 +33,8 @@ describe("native graph-core packaging policy", () => {
     assert.match(releasePublish, /createStagedOpcorePackage/);
     assert.match(releasePublish, /cwd:\s*packageDirs\.get\(packageName\)/);
     assert.doesNotMatch(releasePublish, /cwd:\s*releasePackageDirForName\(packageName\)/);
+    assert.match(releasePublish, /--loglevel", "notice"/);
+    assert.match(releasePublish, /hasTrustedPublishingContext\(\) && !hasTokenAuth\(\) && !options\.dryRun/);
 
     const stageBundle = readFileSync("scripts/stage-opcore-bundle.mjs", "utf8");
     assert.match(stageBundle, /disableLifecycleScripts: true/);


### PR DESCRIPTION
## Summary
- skip npm provenance for token-authenticated publishes so the private-repo first release can publish
- keep provenance for future trusted-publishing auth by requiring GitHub OIDC without token auth
- force npm publish commands to use notice logging so registry failures are visible despite root silent npm config
- add a packaging policy assertion for the release publish auth behavior

## Verification
- node --test tests/native-packaging-policy.test.mjs
- npm run release:hygiene
- npm run release:publish -- --version 0.1.0 --tag latest --dry-run
- npm run ci

## Release Failure Evidence
- Release run 28960961558 attempt 2 failed at `npm publish --access public --tag latest --provenance`
- `the-open-engine/opcore` is currently private, and the existing release receipt reports `privateRepo: true`
