### PR TITLE
feat(validation): make validation file views lazy

### DIFF
--- a/packages/validation-clone/src/clone-check.ts
+++ b/packages/validation-clone/src/clone-check.ts
@@ -87,7 +87,8 @@ async function cloneAnalysisRequest(
   options: Pick<CreateCloneDuplicationCheckOptions, "windowSize" | "minLines" | "minTokens" | "threshold" | "partitions" | "exclude" | "modes">
 ): Promise<CloneAnalysisRequest> {
   const paths = [...cloneInputPaths(context)];
-  const overlays = await cloneOverlays(context, cloneOverlayPaths(context, paths));
+  const overlayPaths = await cloneOverlayPaths(context, paths);
+  const overlays = await cloneOverlays(context, overlayPaths);
   return {
     protocol: CLONE_PROTOCOL,
     ...(context.request.requestId !== undefined ? { requestId: context.request.requestId } : {}),

--- a/packages/validation-clone/src/source-files.ts
+++ b/packages/validation-clone/src/source-files.ts
@@ -15,9 +15,10 @@ export function cloneInputPaths(context: ValidationCheckContext): readonly strin
   );
 }
 
-export function cloneOverlayPaths(context: ValidationCheckContext, paths: readonly string[]): readonly string[] {
+export async function cloneOverlayPaths(context: ValidationCheckContext, paths: readonly string[]): Promise<readonly string[]> {
+  const visibleFiles = await context.fileView.listVisibleFiles();
   return uniqueSorted(
-    [...context.fileView.visibleFiles, ...paths]
+    [...visibleFiles, ...paths]
       .map((path) => normalizeValidationFileViewPath(path))
       .filter(isCloneSourcePath)
   );

--- a/packages/validation-docs/src/checks.ts
+++ b/packages/validation-docs/src/checks.ts
@@ -464,7 +464,8 @@ function docsMentionPath(docs: readonly DocsDocument[], path: string, requireExp
 
 async function sourceSubtreeLoc(context: ValidationCheckContext): Promise<ReadonlyMap<string, number>> {
   const totals = new Map<string, number>();
-  for (const path of context.fileView.visibleFiles) {
+  const visibleFiles = await context.fileView.listVisibleFiles();
+  for (const path of visibleFiles) {
     if (isDocsPath(path) || !isSourceLikePath(path)) continue;
     const result = await context.fileView.readAfter(path);
     if (result.status !== "found") continue;

--- a/packages/validation-policy/src/path-policy.ts
+++ b/packages/validation-policy/src/path-policy.ts
@@ -18,10 +18,15 @@ export function pathPolicyIncludes(path: string, policy: OpcorePathPolicy | unde
 export function withFilteredFileView<T extends Pick<ValidationCheckContext, "fileView">>(context: T, policy: OpcorePathPolicy): T {
   const fileView = context.fileView;
   const filteredOverlays = fileView.overlays.filter((overlay) => pathPolicyIncludes(overlay.path, policy));
+  let filteredVisibleFilesPromise: Promise<readonly string[]> | undefined;
+  const listVisibleFiles = (): Promise<readonly string[]> => {
+    filteredVisibleFilesPromise ??= fileView.listVisibleFiles().then((paths) => paths.filter((path) => pathPolicyIncludes(path, policy)));
+    return filteredVisibleFilesPromise;
+  };
   const filteredFileView: ValidationFileView = {
     ...fileView,
     scopeFiles: fileView.scopeFiles.filter((path) => pathPolicyIncludes(path, policy)),
-    visibleFiles: fileView.visibleFiles.filter((path) => pathPolicyIncludes(path, policy)),
+    listVisibleFiles,
     overlays: filteredOverlays,
     readFile: (path, options) =>
       pathPolicyIncludes(path, policy) ? fileView.readFile(path, options) : Promise.resolve(missingRead(path, options?.state ?? "after")),

--- a/packages/validation/src/overlays.ts
+++ b/packages/validation/src/overlays.ts
@@ -81,7 +81,7 @@ export interface CreateValidationFileViewArgs {
 export interface ValidationFileView {
   readonly overlays: readonly ValidationOverlayEntry[];
   readonly scopeFiles: readonly string[];
-  readonly visibleFiles: readonly string[];
+  listVisibleFiles: () => Promise<readonly string[]>;
   readFile: (path: string, options?: ValidationFileReadOptions) => Promise<ValidationFileReadResult>;
   readBefore: (path: string) => Promise<ValidationFileReadResult>;
   readAfter: (path: string) => Promise<ValidationFileReadResult>;
@@ -134,8 +134,11 @@ export async function createValidationFileView(args: CreateValidationFileViewArg
   const overlayByPath = new Map(overlays.map((overlay) => [overlay.path, overlay]));
   const scopeFiles = uniqueSorted(args.scope.files.map(normalizeValidationFileViewPath));
   const defaultReadState = args.defaultReadState ?? "after";
-  const visibleFiles = await resolveVisibleFiles(args.workspace, args.scope, defaultReadState, scopeFiles, overlays);
-
+  let visibleFilesPromise: Promise<readonly string[]> | undefined;
+  const listVisibleFiles = (): Promise<readonly string[]> => {
+    visibleFilesPromise ??= resolveVisibleFiles(args.workspace, args.scope, defaultReadState, scopeFiles, overlays);
+    return visibleFilesPromise;
+  };
   const readBefore = (path: string): Promise<ValidationFileReadResult> =>
     readWorkspacePath(args.workspace, args.scope, normalizeValidationFileViewPath(path), "before");
   const readAfter = async (path: string): Promise<ValidationFileReadResult> => {
@@ -159,7 +162,7 @@ export async function createValidationFileView(args: CreateValidationFileViewArg
   return {
     overlays,
     scopeFiles,
-    visibleFiles,
+    listVisibleFiles,
     readFile: (path, options = {}) =>
       options.state === "before" || (options.state === undefined && defaultReadState === "before") ? readBefore(path) : readAfter(path),
     readBefore,

--- a/tests/validation-cli.test.mjs
+++ b/tests/validation-cli.test.mjs
@@ -521,10 +521,14 @@ describe("validation CLI", () => {
 
   it("filters validation file view collections through repo path policy", async () => {
     const { withFilteredFileView } = await import("../packages/opcore/dist/path-policy.js");
+    let listVisibleFileCalls = 0;
     const context = {
       fileView: {
         scopeFiles: ["packages/src/index.ts", "docs/notes.ts", "dist/index.js"],
-        visibleFiles: ["packages/src/index.ts", "scripts/build.mjs", "docs/notes.ts", ".ace/runtime.json"],
+        listVisibleFiles: async () => {
+          listVisibleFileCalls += 1;
+          return ["packages/src/index.ts", "scripts/build.mjs", "docs/notes.ts", ".ace/runtime.json"];
+        },
         overlays: [
           { path: "packages/src/index.ts", action: "write", content: "export const value = 1;\n" },
           { path: "docs/notes.ts", action: "write", content: "export const value = 2;\n" },
@@ -542,9 +546,12 @@ describe("validation CLI", () => {
       include: ["packages/", "scripts/"],
       exclude: ["dist/**", ".ace", ".agents"]
     });
+    assert.equal(listVisibleFileCalls, 0);
 
     assert.deepEqual(filtered.fileView.scopeFiles, ["packages/src/index.ts"]);
-    assert.deepEqual(filtered.fileView.visibleFiles, ["packages/src/index.ts", "scripts/build.mjs"]);
+    assert.deepEqual(await filtered.fileView.listVisibleFiles(), ["packages/src/index.ts", "scripts/build.mjs"]);
+    assert.deepEqual(await filtered.fileView.listVisibleFiles(), ["packages/src/index.ts", "scripts/build.mjs"]);
+    assert.equal(listVisibleFileCalls, 1);
     assert.deepEqual(filtered.fileView.overlays.map((overlay) => overlay.path), ["packages/src/index.ts"]);
     assert.equal(filtered.fileView.overlayFor("docs/notes.ts"), undefined);
     assert.equal(filtered.fileView.overlayFor("packages/src/index.ts")?.content, "export const value = 1;\n");

--- a/tests/validation-overlays.test.mjs
+++ b/tests/validation-overlays.test.mjs
@@ -54,6 +54,60 @@ describe("validation overlays", () => {
     assert.deepEqual(view.scopeFiles, ["src/index.ts", "src/unchanged.ts"]);
   });
 
+  it("keeps file reads lazy until visible files are requested", async () => {
+    let listFileCalls = 0;
+    const workspace = testWorkspace({
+      "src/scope.ts": "export const scope = true;",
+      "src/workspace.ts": "export const workspace = true;",
+      "src/delete.ts": "export const deleted = true;"
+    });
+    workspace.listFiles = () => {
+      listFileCalls += 1;
+      return {
+        files: ["src/workspace.ts", "src\\windows.ts", { path: "src/old-name.ts", toPath: "src/renamed.ts" }]
+      };
+    };
+
+    const view = await createValidationFileView({
+      request: request({
+        overlays: [
+          {
+            path: "src\\overlay.ts",
+            action: "write",
+            content: "export const overlay = true;"
+          },
+          {
+            path: "src/delete.ts",
+            action: "delete"
+          }
+        ]
+      }),
+      scope: scope(["src/scope.ts"]),
+      workspace
+    });
+
+    assert.equal((await view.readAfter("src/scope.ts")).status, "found");
+    assert.equal((await view.readBefore("src/scope.ts")).status, "found");
+    assert.equal((await view.readFile("src/scope.ts")).status, "found");
+    assert.equal(await view.exists("src/workspace.ts"), true);
+    assert.equal(view.hasOverlay("src/overlay.ts"), true);
+    assert.equal(view.overlayFor("src\\overlay.ts")?.action, "write");
+    assert.equal(listFileCalls, 0);
+
+    const visibleFiles = await view.listVisibleFiles();
+    assert.equal(listFileCalls, 1);
+    assert.deepEqual(visibleFiles, [
+      "src/delete.ts",
+      "src/overlay.ts",
+      "src/renamed.ts",
+      "src/scope.ts",
+      "src/windows.ts",
+      "src/workspace.ts"
+    ]);
+    assert.deepEqual(await view.listVisibleFiles(), visibleFiles);
+    assert.equal(listFileCalls, 1);
+  });
+
   it("distinguishes delete overlays from missing workspace files", async () => {
     const workspace = testWorkspace({
       "src/remove.ts": "export const remove = true;"

--- a/tests/validation-runner.test.mjs
+++ b/tests/validation-runner.test.mjs
@@ -463,6 +463,36 @@ describe("validation runner", () => {
     assert.equal(observed.content, "export const value = 'overlay';");
   });
 
+  it("does not list workspace files when a files-scoped check reads one explicit file", async () => {
+    let listFileCalls = 0;
+    let observed;
+    const workspace = {
+      ...testWorkspace(),
+      listFiles: () => {
+        listFileCalls += 1;
+        return {
+          files: ["src/index.ts", "src/other.ts"]
+        };
+      }
+    };
+    const result = await createValidationRunner({
+      workspace,
+      checks: [
+        check("types", {
+          run: async (context) => {
+            observed = await context.fileView.readAfter("src/index.ts");
+            return { diagnostics: [] };
+          }
+        })
+      ]
+    }).runValidation(request());
+
+    assert.equal(result.status, "passed");
+    assert.equal(observed.status, "found");
+    assert.equal(observed.content, "export const value = 'disk';");
+    assert.equal(listFileCalls, 0);
+  });
+
   it("passes a graph query session to graph-aware checks", async () => {
     let observedEdges;
     const result = await runner(


### PR DESCRIPTION
Closes #213.

## Summary
- Replace eager `ValidationFileView.visibleFiles` materialization with cached async `listVisibleFiles()`.
- Keep direct reads/existence/overlay lookups path-specific so they do not call `workspace.listFiles()`.
- Update clone/docs/path-policy callers that genuinely need all visible files to request them explicitly.
- Add regression coverage for lazy file-view reads, runner direct reads, and path-policy filtering.

## Verification
- `npm run build`
- `node --test tests/validation-overlays.test.mjs tests/validation-runner.test.mjs tests/validation-cli.test.mjs tests/validation-clone.test.mjs tests/validation-docs.test.mjs`
- `node --test tests/*validation*.test.mjs tests/opcore-agent-gate.test.mjs`
- `npm run ci:local`