### PR TITLE
fix(release): parse npm 11 pack output

### DIFF
--- a/scripts/release-dry-run.mjs
+++ b/scripts/release-dry-run.mjs
@@ -10,7 +10,7 @@ import {
   graphCoreSupportedTargets
 } from "./graph-native-targets.mjs";
 import { publicReleasePackageNames, releasePackageDirForName } from "./release-package-dirs.mjs";
-import { createStagedOpcorePackage } from "./stage-opcore-bundle.mjs";
+import { createStagedOpcorePackage, npmPackResultForPackage } from "./stage-opcore-bundle.mjs";
 
 const releaseVersion = "0.2.0";
 const publicPackages = publicReleasePackageNames;
@@ -87,7 +87,8 @@ function packWorkspace(packageName, destination) {
     const result = run("npm", ["pack", "--json", "--pack-destination", destination], {
       cwd: staged?.packageDir ?? releasePackageDirForName(packageName)
     });
-    const parsed = JSON.parse(result.stdout)[0];
+    const parsed = npmPackResultForPackage(JSON.parse(result.stdout), packageName);
+    if (!parsed) throw new Error(`${packageName} npm pack returned no package result:\n${result.stdout}`);
     if (parsed.version !== releaseVersion) throw new Error(`${packageName} packed version ${parsed.version}, expected ${releaseVersion}`);
     return join(destination, parsed.filename);
   } finally {

--- a/tests/native-packaging-policy.test.mjs
+++ b/tests/native-packaging-policy.test.mjs
@@ -53,6 +53,10 @@ describe("native graph-core packaging policy", () => {
     assert.match(stageBundle, /"pack", "\.", "--dry-run", "--json", "--ignore-scripts"/);
     assert.match(stageBundle, /disableLifecycleScripts: true/);
     assert.match(stageBundle, /delete manifest\.scripts/);
+
+    const releaseDryRun = readFileSync("scripts/release-dry-run.mjs", "utf8");
+    assert.match(releaseDryRun, /npmPackResultForPackage\(JSON\.parse\(result\.stdout\), packageName\)/);
+    assert.doesNotMatch(releaseDryRun, /JSON\.parse\(result\.stdout\)\[0\]/);
   });
 
   it("encodes npm os/cpu support in each bundled native package manifest", () => {


### PR DESCRIPTION
## Summary

- reuse the shared npm pack-result parser in release:dry-run
- accept npm 11 workspace-keyed JSON during the publish workflow
- fail with the raw npm result instead of an undefined-property TypeError

## Verification

- node --test tests/native-packaging-policy.test.mjs
- npm run release:dry-run (Node 24.15.0, npm 11.12.1)
- opcore check --changed --base origin/dev --json

This fixes the publish failure in Release run 29277207454.