### PR TITLE
Release Opcore 0.2.0: npm 11 publish repair

### DIFF
--- a/scripts/release-dry-run.mjs
+++ b/scripts/release-dry-run.mjs
@@ -10,7 +10,7 @@ import {
   graphCoreSupportedTargets
 } from "./graph-native-targets.mjs";
 import { publicReleasePackageNames, releasePackageDirForName } from "./release-package-dirs.mjs";
-import { createStagedOpcorePackage } from "./stage-opcore-bundle.mjs";
+import { createStagedOpcorePackage, npmPackResultForPackage } from "./stage-opcore-bundle.mjs";
 
 const releaseVersion = "0.2.0";
 const publicPackages = publicReleasePackageNames;
@@ -87,7 +87,8 @@ function packWorkspace(packageName, destination) {
     const result = run("npm", ["pack", "--json", "--pack-destination", destination], {
       cwd: staged?.packageDir ?? releasePackageDirForName(packageName)
     });
-    const parsed = JSON.parse(result.stdout)[0];
+    const parsed = npmPackResultForPackage(JSON.parse(result.stdout), packageName);
+    if (!parsed) throw new Error(`${packageName} npm pack returned no package result:\n${result.stdout}`);
     if (parsed.version !== releaseVersion) throw new Error(`${packageName} packed version ${parsed.version}, expected ${releaseVersion}`);
     return join(destination, parsed.filename);
   } finally {

--- a/tests/native-packaging-policy.test.mjs
+++ b/tests/native-packaging-policy.test.mjs
@@ -53,6 +53,10 @@ describe("native graph-core packaging policy", () => {
     assert.match(stageBundle, /"pack", "\.", "--dry-run", "--json", "--ignore-scripts"/);
     assert.match(stageBundle, /disableLifecycleScripts: true/);
     assert.match(stageBundle, /delete manifest\.scripts/);
+
+    const releaseDryRun = readFileSync("scripts/release-dry-run.mjs", "utf8");
+    assert.match(releaseDryRun, /npmPackResultForPackage\(JSON\.parse\(result\.stdout\), packageName\)/);
+    assert.doesNotMatch(releaseDryRun, /JSON\.parse\(result\.stdout\)\[0\]/);
   });
 
   it("encodes npm os/cpu support in each bundled native package manifest", () => {


### PR DESCRIPTION
## Release repair

Promotes the npm 11 pack-output compatibility fix required by the 0.2.0 publish workflow.

The first 0.2.0 release run completed all builds and staging, then failed before publication when release:dry-run parsed npm 11 workspace-keyed JSON as an array. This change reuses the shared parser already validated for that output shape.

## Verification

- Node 24.15.0 / npm 11.12.1 release dry-run passed
- packaging regression suite passed
- PR #231 CI, CodeQL, and provenance passed

After merge, successful main CI will rerun the automated 0.2.0 publication with the checked-in release notes.