### PR TITLE
ci: guard setup worktree cleanliness

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ace:sync": "bash ./scripts/run-ace.sh sync",
     "ace:validate": "bash ./scripts/run-ace.sh validate",
     "setup": "npm ci && npm run setup:tools",
+    "setup:check-clean": "bash ./scripts/ci/check-setup-clean-worktree.sh",
     "setup:tools": "bash ./scripts/setup-current-tools.sh",
     "test": "node --test tests/*.test.mjs",
     "test:ci": "node scripts/run-test-ci.mjs",

--- a/scripts/check-workspace.mjs
+++ b/scripts/check-workspace.mjs
@@ -66,6 +66,7 @@ for (const scriptName of [
   "ci",
   "ci:local",
   "setup",
+  "setup:check-clean",
   "setup:tools",
   "verify",
   "test:ci",
@@ -454,6 +455,7 @@ function validateLocalCiEquivalent() {
   const localCi = readFileSync("scripts/ci/run-local-ci-equivalent.sh", "utf8");
   for (const token of [
     "npm run setup:tools",
+    "npm run setup:check-clean",
     "npm run ci",
     "npm run current-tools:validate-all",
     "npm run current-tools:validate-rust-graph"

--- a/scripts/ci/check-setup-clean-worktree.sh
+++ b/scripts/ci/check-setup-clean-worktree.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+temp_root="$(mktemp -d "${TMPDIR:-/tmp}/opcore-setup-clean.XXXXXX")"
+worktree_path="${temp_root}/repo"
+
+cleanup() {
+  git -C "${repo_root}" worktree remove --force "${worktree_path}" >/dev/null 2>&1 || true
+  rm -rf "${temp_root}"
+}
+trap cleanup EXIT
+
+git -C "${repo_root}" worktree add --detach "${worktree_path}" HEAD
+
+(
+  cd "${worktree_path}"
+  npm run setup
+)
+
+status="$(git -C "${worktree_path}" status --short --untracked-files=normal)"
+if [ -n "${status}" ]; then
+  printf 'error: npm run setup must leave a fresh worktree clean.\n' >&2
+  printf 'Dirty paths after setup:\n%s\n' "${status}" >&2
+  exit 1
+fi
+
+printf 'setup clean-worktree check passed\n'

--- a/scripts/ci/run-local-ci-equivalent.sh
+++ b/scripts/ci/run-local-ci-equivalent.sh
@@ -99,6 +99,7 @@ if docs_or_agent_only_changes "${changed_file_list}"; then
 fi
 
 run_step npm run setup:tools
+run_step npm run setup:check-clean
 snapshot_generated_artifacts
 run_step npm run ci
 restore_generated_artifacts


### PR DESCRIPTION
Opcore ship runs depend on setup being idempotent in a fresh worktree. If setup rewrites tracked artifacts, Zeroshot validators see unrelated dirt and fail far from the real cause.

Add a CI guard that creates a throwaway worktree, runs `npm run setup`, and fails if the worktree is not clean afterward. Wire that guard into the local CI-equivalent proof so this class of failure is caught before ship runs get stuck.

Verification:
- `bash -n scripts/ci/check-setup-clean-worktree.sh scripts/ci/run-local-ci-equivalent.sh`
- `node scripts/check-workspace.mjs`
- `npm run setup:check-clean`

Refs #225