### PR TITLE
ci: target zeroshot feature runs at dev

### DIFF
--- a/.zeroshot/settings.json
+++ b/.zeroshot/settings.json
@@ -1,9 +1,9 @@
 {
   "github": {
-    "prBase": "main"
+    "prBase": "dev"
   },
   "worktree": {
-    "baseRef": "origin/main",
+    "baseRef": "origin/dev",
     "setup": [
       "npm run setup"
     ]

--- a/scripts/check-workspace.mjs
+++ b/scripts/check-workspace.mjs
@@ -304,8 +304,8 @@ for (const rustCheck of ["cargo fmt --check", "cargo clippy --all-targets --all-
 }
 
 const zeroshot = readJson(".zeroshot/settings.json");
-if (zeroshot.github?.prBase !== "main" || zeroshot.worktree?.baseRef !== "origin/main") {
-  fail("Zeroshot must target the lattice main branch");
+if (zeroshot.github?.prBase !== "dev" || zeroshot.worktree?.baseRef !== "origin/dev") {
+  fail("Zeroshot feature runs must target the lattice dev branch");
 }
 if (!zeroshot.worktree?.setup?.includes("npm run setup")) fail("Zeroshot setup must generate current-tool wrappers");
 


### PR DESCRIPTION
Opcore CI only allows dev to promote into main, but the repo-local Zeroshot settings still targeted main for feature runs.

Point feature worktrees and PRs at dev and update the workspace policy so the repo enforces that branch ownership locally before wasting a failed main-target PR.

Verification:
- node scripts/check-workspace.mjs