### PR TITLE
Fix agent gate local opcore resolution

### DIFF
--- a/packages/opcore/src/agent-gate.ts
+++ b/packages/opcore/src/agent-gate.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
   createNodeEditWorkspace,
   createPatchEditPlan,
@@ -240,12 +240,15 @@ async function patchOverlays(repoRoot: string, input: Record<string, unknown>): 
 }
 
 function runPreWriteValidation(request: ValidationRequest): PreWriteValidationReceipt {
+  const repoRoot = request.repo.repoRoot;
+  if (repoRoot === undefined) throw new Error("pre-write validation requires repoRoot");
   const tempDir = mkdtempSync(resolve(tmpdir(), "opcore-agent-gate-"));
   const requestPath = resolve(tempDir, "validation-request.json");
   try {
     writeFileSync(requestPath, `${JSON.stringify(request)}\n`, "utf8");
     const result = spawnSync("opcore", ["validate", "pre-write", "--request-file", requestPath, "--timeout-ms", String(validationTimeoutMs), "--json"], {
-      cwd: request.repo.repoRoot,
+      cwd: repoRoot,
+      env: validationSpawnEnv(repoRoot),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
     });
@@ -258,8 +261,17 @@ function runPreWriteValidation(request: ValidationRequest): PreWriteValidationRe
   }
 }
 
-function parseValidationOutput(stdout: string): { receipt?: PreWriteValidationReceipt } | undefined {
-  const trimmed = stdout.trim();
+function validationSpawnEnv(repoRoot: string): Record<string, string | undefined> {
+  const env = { ...(process.env ?? {}) };
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const currentPath = env[pathKey] ?? "";
+  const localBin = join(repoRoot, "node_modules", ".bin");
+  env[pathKey] = currentPath.length > 0 ? `${localBin}${delimiter}${currentPath}` : localBin;
+  return env;
+}
+
+function parseValidationOutput(stdout: string | null | undefined): { receipt?: PreWriteValidationReceipt } | undefined {
+  const trimmed = (stdout ?? "").trim();
   if (trimmed.length === 0) return undefined;
   const parsed = JSON.parse(trimmed) as unknown;
   if (!isRecord(parsed) || !isRecord(parsed.receipt)) return undefined;

--- a/packages/opcore/src/node-shims.d.ts
+++ b/packages/opcore/src/node-shims.d.ts
@@ -84,6 +84,7 @@ declare module "node:module" {
 }
 declare module "node:path" {
   export function basename(path: string): string;
+  export const delimiter: string;
   export function dirname(path: string): string;
   export function extname(path: string): string;
   export function isAbsolute(path: string): boolean;

--- a/tests/opcore-agent-gate.test.mjs
+++ b/tests/opcore-agent-gate.test.mjs
@@ -86,6 +86,66 @@ describe("Opcore agent write gate adapter", () => {
       rmSync(temp, { recursive: true, force: true });
     }
   });
+
+  it("resolves repo-local opcore from node_modules/.bin when the hook PATH is plain", () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-agent-gate-local-bin-"));
+    try {
+      initTypeScriptFixture(temp);
+      createOpcoreShim(temp, "node_modules/.bin");
+      runOpcore(["init", "--repo", temp, "--local", "--approve", "--json"], temp, 0);
+      const hookPath = join(temp, ".opcore", "hooks", "opcore-agent-gate.mjs");
+
+      const clean = runHook(
+        hookPath,
+        {
+          cwd: temp,
+          hook_event_name: "PreToolUse",
+          tool_name: "Write",
+          tool_input: {
+            file_path: join(temp, "src", "index.ts"),
+            content: "export const value: number = 2;\n"
+          },
+          env: { ...process.env, PATH: "/usr/bin:/bin" },
+          expectedStatus: 0
+        }
+      );
+
+      assert.equal(clean.stderr, "");
+      assert.equal(readFileSync(join(temp, "src", "index.ts"), "utf8"), "export const value: number = 1;\n");
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a missing opcore command without crashing on empty spawn output", () => {
+    const temp = mkdtempSync(join(tmpdir(), "opcore-agent-gate-missing-bin-"));
+    try {
+      initTypeScriptFixture(temp);
+      runOpcore(["init", "--repo", temp, "--local", "--approve", "--json"], temp, 0);
+      const hookPath = join(temp, ".opcore", "hooks", "opcore-agent-gate.mjs");
+
+      const blocked = runHook(
+        hookPath,
+        {
+          cwd: temp,
+          hook_event_name: "PreToolUse",
+          tool_name: "Write",
+          tool_input: {
+            file_path: join(temp, "src", "index.ts"),
+            content: "export const value: number = 2;\n"
+          },
+          env: { ...process.env, PATH: "" },
+          expectedStatus: 2
+        }
+      );
+
+      assert.match(blocked.stderr, /validation command failed/);
+      assert.match(blocked.stderr, /ENOENT/);
+      assert.doesNotMatch(blocked.stderr, /Cannot read properties/);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
 });
 
 function initTypeScriptFixture(root) {
@@ -98,8 +158,8 @@ function initTypeScriptFixture(root) {
   writeFixtureFile(root, "src/index.ts", "export const value: number = 1;\n");
 }
 
-function createOpcoreShim(root) {
-  const shimDir = join(root, "bin");
+function createOpcoreShim(root, relativeDir = "bin") {
+  const shimDir = join(root, relativeDir);
   mkdirSync(shimDir, { recursive: true });
   const shimPath = join(shimDir, "opcore");
   writeFileSync(shimPath, `#!/usr/bin/env sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(opcoreBin)} "$@"\n`);


### PR DESCRIPTION
## Summary

Fix the Opcore agent write gate so pre-write validation resolves a repository-local `opcore` binary when the hook process has a plain session `PATH`.

## Root Cause

The gate spawned `opcore validate pre-write` by command name only. In installed hook environments, `opcore` may exist at `node_modules/.bin/opcore` without that directory being present in `PATH`. When spawn failed with `ENOENT`, Node returned nullish stdout and the gate crashed while trimming it.

## Changes

- Prepend `<repoRoot>/node_modules/.bin` to the validation child process `PATH` while preserving the existing environment and platform delimiter.
- Require the gate-created pre-write request to have a `repoRoot` before spawning validation.
- Treat nullish validation stdout as empty output so missing command failures report cleanly instead of throwing a TypeError.
- Add regression coverage for repo-local bin resolution and missing-bin no-crash behavior.

## Independent Review

Independent reviewer approved the diff with no blocking findings. They specifically checked placement, generated-hook behavior, `PATH`/`Path` casing, platform delimiter usage, failure semantics, and test adequacy.

## Validation

- `git diff --check`
- `node --test tests/opcore-agent-gate.test.mjs`
- `npx tsc -b --pretty false`
- `npm run lint`
- `PATH="$PWD/node_modules/.bin:$PATH" opcore check changed --base origin/dev --json`

Note: full `npm run build` is blocked in this environment because `x86_64-linux-musl-gcc` is not installed for the native artifact step.